### PR TITLE
Added BoolToObjectConverter

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -9,5 +9,6 @@
 - [ ] I have tested on an iOS device.
 - [ ] I have added unit tests
 
->*Please add pictures / Gifs if possible
+>*Please add pictures / Gifs if possible*
 >*Todo List can be checked by putting a `X` inside the brackets*
+>*Remember to update our `wiki` after this PR is merged*

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,13 @@
+## Added / Fixed
+
+- Added a new feature
+- Fixed a bug
+
+## Todo List
+
+- [ ] I have tested on an Android device.
+- [ ] I have tested on an iOS device.
+- [ ] I have added unit tests
+
+>*Please add pictures / Gifs if possible
+>*Todo List can be checked by putting a `X` inside the brackets*

--- a/src/DIPS.Xamarin.UI/Converters/ValueConverters/BoolToObjectConverter.cs
+++ b/src/DIPS.Xamarin.UI/Converters/ValueConverters/BoolToObjectConverter.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Text;
 using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
@@ -23,7 +21,7 @@ namespace DIPS.Xamarin.UI.Converters.ValueConverters
         /// </summary>
         public object? FalseObject { get; set; }
         /// <summary>
-        /// A boolean value to turn on or inverting of the output values
+        /// A boolean value to set if the output value should be inverted
         /// </summary>
         public bool Inverted { get; set; }
 

--- a/src/DIPS.Xamarin.UI/Converters/ValueConverters/BoolToObjectConverter.cs
+++ b/src/DIPS.Xamarin.UI/Converters/ValueConverters/BoolToObjectConverter.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace DIPS.Xamarin.UI.Converters.ValueConverters
+{
+    /// <summary>
+    /// Converters an boolean input value to it's respective <see cref="TrueObject"/> or <see cref="FalseObject"/> depending on the <see cref="Inverted"/> value
+    /// </summary>
+    public class BoolToObjectConverter : IValueConverter, IMarkupExtension
+    {
+        /// <summary>
+        /// The value that will return if the boolean input is true
+        /// <remarks>Will be the return value if <see cref="Inverted"/> is set to true</remarks>
+        /// </summary>
+        public object? TrueObject { get; set; }
+        /// <summary>
+        /// The value that will return if the boolean input is false
+        /// <remarks>Will be the return value if <see cref="Inverted"/> is set to false</remarks>
+        /// </summary>
+        public object? FalseObject { get; set; }
+        /// <summary>
+        /// A boolean value to turn on or inverting of the output values
+        /// </summary>
+        public bool Inverted { get; set; }
+
+        /// <inheritdoc />
+        public object? Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (!(value is bool inputValue)) throw new ArgumentException($"Input value has to be of type {nameof(Boolean)}");
+            if (TrueObject?.GetType() != FalseObject?.GetType())
+                throw new ArgumentException($"{nameof(TrueObject)} has to be the same type as {FalseObject}");
+
+            return Inverted ? (inputValue) ? FalseObject : TrueObject : (inputValue) ? TrueObject : FalseObject;
+        }
+
+        /// <inheritdoc />
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public object ProvideValue(IServiceProvider serviceProvider)
+        {
+            return this;
+        }
+    }
+}

--- a/src/Samples/DIPS.Xamarin.UI.Samples/Converters/ConvertersPage.xaml
+++ b/src/Samples/DIPS.Xamarin.UI.Samples/Converters/ConvertersPage.xaml
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             x:Class="DIPS.Xamarin.UI.Samples.Converters.ConvertersPage"
+             Title="Converters">
+    <ContentPage.Content>
+        <StackLayout>
+            <Button Text="BoolToObjectConverter"
+                    Command="{Binding NavigateToCommand}"
+                    CommandParameter="BoolToObject" />
+            <Button Text="InvertedBoolConverter"
+                    Command="{Binding NavigateToCommand}"
+                    CommandParameter="InvertedBool" />
+            <Button Text="IsEmptyConverter"
+                    Command="{Binding NavigateToCommand}"
+                    CommandParameter="IsEmptyConverter" />
+        </StackLayout>
+    </ContentPage.Content>
+</ContentPage>

--- a/src/Samples/DIPS.Xamarin.UI.Samples/Converters/ConvertersPage.xaml.cs
+++ b/src/Samples/DIPS.Xamarin.UI.Samples/Converters/ConvertersPage.xaml.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace DIPS.Xamarin.UI.Samples.Converters
+{
+    [XamlCompilation(XamlCompilationOptions.Compile)]
+    public partial class ConvertersPage : ContentPage
+    {
+        public ConvertersPage()
+        {
+            BindingContext = new ConvertersViewModel(Application.Current.MainPage.Navigation);
+            InitializeComponent();
+        }
+    }
+}

--- a/src/Samples/DIPS.Xamarin.UI.Samples/Converters/ConvertersViewModel.cs
+++ b/src/Samples/DIPS.Xamarin.UI.Samples/Converters/ConvertersViewModel.cs
@@ -1,0 +1,36 @@
+﻿using System.Windows.Input;
+using DIPS.Xamarin.UI.Samples.Controls.DatePicker;
+using DIPS.Xamarin.UI.Samples.Converters.ValueConverters;
+using Xamarin.Forms;
+
+namespace DIPS.Xamarin.UI.Samples.Converters
+{
+    public class ConvertersViewModel
+    {
+        private readonly INavigation m_navigation;
+
+        public ConvertersViewModel(INavigation navigation)
+        {
+            m_navigation = navigation;
+            NavigateToCommand = new Command<string>(NavigateTo);
+        }
+
+        public ICommand NavigateToCommand { get; }
+
+        private void NavigateTo(string parameter)
+        {
+            switch (parameter)
+            {
+                case "BoolToObject":
+                    m_navigation.PushAsync(new BoolToObjectConverterPage());
+                    break;
+                case "InvertedBool":
+                    m_navigation.PushAsync(new InvertedBoolConverterPage());
+                    break;
+                case "IsEmptyConverter":
+                    m_navigation.PushAsync(new IsEmptyConverterPage());
+                    break;
+            }
+        }
+    }
+}

--- a/src/Samples/DIPS.Xamarin.UI.Samples/Converters/ValueConverters/BoolToObjectConverterPage.xaml
+++ b/src/Samples/DIPS.Xamarin.UI.Samples/Converters/ValueConverters/BoolToObjectConverterPage.xaml
@@ -1,0 +1,38 @@
+﻿<?xml version="1.0"
+      encoding="utf-8"?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:dxui="http://dips.xamarin.ui.com"
+             xmlns:ValueConverters="clr-namespace:DIPS.Xamarin.UI.Samples.Converters.ValueConverters;assembly=DIPS.Xamarin.UI.Samples"
+             mc:Ignorable="d"
+             x:Class="DIPS.Xamarin.UI.Samples.Converters.ValueConverters.BoolToObjectConverterPage"
+             Title="BoolToObjectConverter">
+    <ContentPage.BindingContext>
+        <ValueConverters:BoolToObjectConverterViewModel />
+    </ContentPage.BindingContext>
+    <ContentPage.Content>
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition  Height="Auto"/>
+                <RowDefinition />
+            </Grid.RowDefinitions>
+
+            <StackLayout Grid.Row="0"
+                         Orientation="Horizontal">
+                <CheckBox IsChecked="{Binding SomeLogicalProperty}" />
+                <Label Text="Set me" VerticalOptions="Center"/>
+            </StackLayout>
+
+            <StackLayout Grid.Row="1">
+                <Label
+                    Opacity="{Binding SomeLogicalProperty, Converter={dxui:BoolToObjectConverter TrueObject=0.5, FalseObject=1}}"
+                    Text="My opacity changes" />
+                <Label
+                    Opacity="{Binding SomeLogicalProperty, Converter={dxui:BoolToObjectConverter TrueObject=0.5, FalseObject=1, Inverted=True}}"
+                    Text="My opacity is inverted" />
+            </StackLayout>
+        </Grid>
+    </ContentPage.Content>
+</ContentPage>

--- a/src/Samples/DIPS.Xamarin.UI.Samples/Converters/ValueConverters/BoolToObjectConverterPage.xaml.cs
+++ b/src/Samples/DIPS.Xamarin.UI.Samples/Converters/ValueConverters/BoolToObjectConverterPage.xaml.cs
@@ -1,5 +1,10 @@
-﻿using System.ComponentModel;
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
 using DIPS.Xamarin.UI.Extensions;
 using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
@@ -7,24 +12,24 @@ using Xamarin.Forms.Xaml;
 namespace DIPS.Xamarin.UI.Samples.Converters.ValueConverters
 {
     [XamlCompilation(XamlCompilationOptions.Compile)]
-    public partial class InvertedBoolConverterPage : ContentPage
+    public partial class BoolToObjectConverterPage : ContentPage
     {
-        public InvertedBoolConverterPage()
+        public BoolToObjectConverterPage()
         {
             InitializeComponent();
         }
     }
 
-    public class InvertedBoolConverterViewModel : INotifyPropertyChanged
+    public class BoolToObjectConverterViewModel : INotifyPropertyChanged
     {
         private bool m_someLogicalProperty;
+        public event PropertyChangedEventHandler PropertyChanged;
 
         public bool SomeLogicalProperty
         {
             get => m_someLogicalProperty;
             set => this.Set(ref m_someLogicalProperty, value, PropertyChanged);
         }
-
-        public event PropertyChangedEventHandler PropertyChanged;
     }
+
 }

--- a/src/Samples/DIPS.Xamarin.UI.Samples/Converters/ValueConverters/InvertedBoolConverterPage.xaml
+++ b/src/Samples/DIPS.Xamarin.UI.Samples/Converters/ValueConverters/InvertedBoolConverterPage.xaml
@@ -8,12 +8,17 @@
              xmlns:ValueConverters="clr-namespace:DIPS.Xamarin.UI.Samples.Converters.ValueConverters;assembly=DIPS.Xamarin.UI.Samples"
              mc:Ignorable="d"
              x:Class="DIPS.Xamarin.UI.Samples.Converters.ValueConverters.InvertedBoolConverterPage"
-             x:DataType="ValueConverters:InvertedBoolConverterViewModel">
+             x:DataType="ValueConverters:InvertedBoolConverterViewModel"
+             Title="InvertedBoolConverter">
     <ContentPage.BindingContext>
         <ValueConverters:InvertedBoolConverterViewModel />
     </ContentPage.BindingContext>
     <ContentPage.Content>
         <StackLayout>
+            <StackLayout Orientation="Horizontal">
+                <CheckBox IsChecked="{Binding SomeLogicalProperty}"/>
+                <Label Text="Invert it!"/>
+            </StackLayout>
             <Label Text="Welcome to Xamarin.Forms!"
                    IsVisible="{Binding SomeLogicalProperty, Converter={dxui:InvertedBoolConverter}}"
                    VerticalOptions="CenterAndExpand"

--- a/src/Samples/DIPS.Xamarin.UI.Samples/Converters/ValueConverters/IsEmptyConverterPage.xaml
+++ b/src/Samples/DIPS.Xamarin.UI.Samples/Converters/ValueConverters/IsEmptyConverterPage.xaml
@@ -8,7 +8,8 @@
              xmlns:ValueConverters="clr-namespace:DIPS.Xamarin.UI.Samples.Converters.ValueConverters;assembly=DIPS.Xamarin.UI.Samples"
              mc:Ignorable="d"
              x:Class="DIPS.Xamarin.UI.Samples.Converters.ValueConverters.IsEmptyConverterPage"
-             x:DataType="ValueConverters:IsEmptyConverterViewModel">
+             x:DataType="ValueConverters:IsEmptyConverterViewModel"
+             Title="IsEmptyConveter">
     <ContentPage.BindingContext>
         <ValueConverters:IsEmptyConverterViewModel />
     </ContentPage.BindingContext>

--- a/src/Samples/DIPS.Xamarin.UI.Samples/DIPS.Xamarin.UI.Samples.csproj
+++ b/src/Samples/DIPS.Xamarin.UI.Samples/DIPS.Xamarin.UI.Samples.csproj
@@ -25,6 +25,12 @@
     <EmbeddedResource Update="Controls\DatePicker\DatePickerPage.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
+    <EmbeddedResource Update="Converters\ConvertersPage.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Update="Converters\ValueConverters\BoolToObjectConverterPage.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
     <EmbeddedResource Update="Converters\ValueConverters\InvertedBoolConverterPage.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>

--- a/src/Samples/DIPS.Xamarin.UI.Samples/MainPage.xaml
+++ b/src/Samples/DIPS.Xamarin.UI.Samples/MainPage.xaml
@@ -11,6 +11,7 @@
 
     <StackLayout>
         <Button Text="Controls" Command="{Binding NavigateToCommand}" CommandParameter="Controls"/>
+        <Button Text="Converters" Command="{Binding NavigateToCommand}" CommandParameter="Converters"/>
     </StackLayout>
 
 </ContentPage>

--- a/src/Samples/DIPS.Xamarin.UI.Samples/MainViewModel.cs
+++ b/src/Samples/DIPS.Xamarin.UI.Samples/MainViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using System.Windows.Input;
 using DIPS.Xamarin.UI.Samples.Controls;
 using DIPS.Xamarin.UI.Samples.Controls.DatePicker;
+using DIPS.Xamarin.UI.Samples.Converters;
 using Xamarin.Forms;
 
 namespace DIPS.Xamarin.UI.Samples
@@ -19,8 +20,15 @@ namespace DIPS.Xamarin.UI.Samples
 
         private void NavigateTo(string parameter)
         {
-            if (parameter.Equals("Controls"))
-                m_navigation.PushAsync(new ControlsPage());
+            switch (parameter)
+            {
+                case "Controls":
+                    m_navigation.PushAsync(new ControlsPage());
+                    break;
+                case "Converters":
+                    m_navigation.PushAsync(new ConvertersPage());
+                    break;
+            }
         }
     }
 }

--- a/src/Tests/DIPS.Xamarin.UI.Tests/Converters/ValueConverters/BoolToObjectConverterTests.cs
+++ b/src/Tests/DIPS.Xamarin.UI.Tests/Converters/ValueConverters/BoolToObjectConverterTests.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using DIPS.Xamarin.UI.Converters.ValueConverters;
+using FluentAssertions;
+using Xunit;
+
+namespace DIPS.Xamarin.UI.Tests.Converters.ValueConverters
+{
+    public class BoolToObjectConverterTests
+    {
+        private readonly BoolToObjectConverter m_boolToObjectConverter;
+
+        public BoolToObjectConverterTests()
+        {
+            m_boolToObjectConverter = new BoolToObjectConverter();
+        }
+
+        [Theory]
+        [InlineData(10, 20)]
+        [InlineData("True string", "False string")]
+        [InlineData(0.01, 0.02)]
+        [InlineData(0.01f, 0.02f)]
+        [InlineData(10, 20, true)]
+        [InlineData("True string", "False string", true)]
+        [InlineData(0.01, 0.02, true)]
+        [InlineData(0.01f, 0.02f, true)]
+
+        public void Convert_WhenValueIsTrue_CorrectOutput(object trueObject, object falseObject, bool inverted = false)
+        {
+            m_boolToObjectConverter.TrueObject = trueObject;
+            m_boolToObjectConverter.FalseObject = falseObject;
+            m_boolToObjectConverter.Inverted = inverted;
+
+            var result = m_boolToObjectConverter.Convert(true, null, null, null);
+
+            result.Should().Be(inverted ? falseObject : trueObject);
+        }
+
+        [Theory]
+        [InlineData(10, 20)]
+        [InlineData("True string", "False string")]
+        [InlineData(0.01, 0.02)]
+        [InlineData(0.01f, 0.02f)]
+        [InlineData(10, 20, true)]
+        [InlineData("True string", "False string", true)]
+        [InlineData(0.01, 0.02, true)]
+        [InlineData(0.01f, 0.02f, true)]
+
+        public void Convert_WhenValueIsFalse_CorrectOutput(object trueObject, object falseObject, bool inverted = false)
+        {
+            m_boolToObjectConverter.TrueObject = trueObject;
+            m_boolToObjectConverter.FalseObject = falseObject;
+            m_boolToObjectConverter.Inverted = inverted;
+
+            var result = m_boolToObjectConverter.Convert(false, null, null, null);
+
+            result.Should().Be(inverted ? trueObject : falseObject);
+        }
+
+        [Fact]
+        public void Convert_TrueFalseObjectsAreDifferent_ThrowsArgumentException()
+        {
+            m_boolToObjectConverter.TrueObject = "2.0";
+            m_boolToObjectConverter.FalseObject = 2.0;
+
+            Action act = () => m_boolToObjectConverter.Convert(false, null, null, null);
+
+            act.Should().Throw<ArgumentException>();
+        }
+
+        [Fact]
+        public void Convert_InputIsNull_ThrowsArgumentException()
+        {
+            Action act = () => m_boolToObjectConverter.Convert(null, null, null, null);
+
+            act.Should().Throw<ArgumentException>();
+        }
+    }
+}


### PR DESCRIPTION
## Added / Fixed
- Added `BoolToObjectConverter`
    - This converter can be used by our consumers to convert a boolean value to whatever object they want. 
## Useful scenario
You want to change the `Opacity` of a `Label` based on a `boolean` value in your view model.

## Todo List

- [X] I have tested on an Android device.
- [X] I have tested on an iOS device.
- [X] I have added unit tests

>*Please add pictures / Gifs if possible
>*Todo List can be checked by putting a `X` inside the brackets*
