### PR TITLE
Set `HasBorder` to obsolete and removed code to turn toggle it in plat…

### DIFF
--- a/src/DIPS.Xamarin.UI.Android/Renderers/DatePicker/DatePickerImplementation.cs
+++ b/src/DIPS.Xamarin.UI.Android/Renderers/DatePicker/DatePickerImplementation.cs
@@ -1,6 +1,4 @@
-﻿using System.ComponentModel;
-using Android.Content;
-using Android.Graphics.Drawables;
+﻿using Android.Content;
 using DIPS.Xamarin.UI.Android.Renderers.DatePicker;
 using Xamarin.Forms;
 using Xamarin.Forms.Platform.Android;
@@ -11,21 +9,13 @@ using DatePicker = DIPS.Xamarin.UI.Controls.DatePicker.DatePicker;
 namespace DIPS.Xamarin.UI.Android.Renderers.DatePicker
 {
     /// <inheritdoc />
-    public class DatePickerImplementation : global::Xamarin.Forms.Platform.Android.DatePickerRenderer
+    public class DatePickerImplementation : DatePickerRenderer
     {
-        private Controls.DatePicker.DatePicker m_datePicker;
-        private Drawable m_defaultBackground;
-        private int m_defaultBottomPadding;
-        private LayoutParams m_defaultLayoutParmeters;
-        private int m_defaultLeftPadding;
-        private int m_defaultRightPadding;
-        private int m_defaultTopPadding;
-
         /// <inheritdoc />
         public DatePickerImplementation(Context context) : base(context) { }
 
         /// <summary>
-        /// Method to use when linking in order to keep the assembly
+        ///     Method to use when linking in order to keep the assembly
         /// </summary>
         public static void Initialize() { }
 
@@ -34,72 +24,16 @@ namespace DIPS.Xamarin.UI.Android.Renderers.DatePicker
         {
             base.OnElementChanged(e);
 
-            if (e.OldElement != null) Unsubscribe();
-
-            if (e.NewElement != null)
-                if (e.NewElement is Controls.DatePicker.DatePicker datePicker)
-                {
-                    m_datePicker = datePicker; ;
-
-                    SubscribeToEvents();
-                    SaveDefaultValues();
-                    InitialChecks();
-                }
-        }
-
-        private void InitialChecks()
-        {
-            if (!m_datePicker.HasBorder)
+            if (e.OldElement != null)
             {
+                //Clean up
+            }
+
+            if (e.NewElement is Controls.DatePicker.DatePicker)
+            {
+                //Initialize
                 TurnOffBorder();
             }
-        }
-
-        private void Unsubscribe()
-        {
-            m_datePicker.PropertyChanged -= OnPropertyChanged;
-        }
-
-        private void SaveDefaultValues()
-        {
-            m_defaultBackground = Control.Background;
-            m_defaultLayoutParmeters = Control.LayoutParameters;
-            m_defaultLeftPadding = Control.PaddingLeft;
-            m_defaultRightPadding = Control.PaddingRight;
-            m_defaultBottomPadding = Control.PaddingBottom;
-            m_defaultTopPadding = Control.PaddingTop;
-        }
-
-        private void SubscribeToEvents()
-        {
-            m_datePicker.PropertyChanged += OnPropertyChanged;
-        }
-
-        private void OnPropertyChanged(object sender, PropertyChangedEventArgs e)
-        {
-            if (e.PropertyName.Equals(nameof(m_datePicker.HasBorder)))
-            {
-                ToggleBorder();
-            }
-        }
-
-        private void ToggleBorder()
-        {
-            if (m_datePicker.HasBorder)
-            {
-                TurnOnBorder();
-            }
-            else
-            {
-                TurnOffBorder();
-            }
-        }
-
-        private void TurnOnBorder()
-        {
-            Control.Background = m_defaultBackground;
-            Control.LayoutParameters = m_defaultLayoutParmeters;
-            Control.SetPadding(m_defaultLeftPadding, m_defaultTopPadding, m_defaultRightPadding, m_defaultBottomPadding);
         }
 
         private void TurnOffBorder()

--- a/src/DIPS.Xamarin.UI.iOS/Renderers/DatePicker/DatePickerImplementation.cs
+++ b/src/DIPS.Xamarin.UI.iOS/Renderers/DatePicker/DatePickerImplementation.cs
@@ -12,10 +12,6 @@ namespace DIPS.Xamarin.UI.iOS.Renderers.DatePicker
     /// <inheritdoc />
     public class DatePickerImplementation : DatePickerRenderer
     {
-        private Controls.DatePicker.DatePicker m_datePicker;
-        private nfloat m_defaultLayerBorderWith;
-        private UITextBorderStyle m_defaultBorderStyle;
-
         /// <summary>
         /// Method to use when linking in order to keep the assembly
         /// </summary>
@@ -28,71 +24,15 @@ namespace DIPS.Xamarin.UI.iOS.Renderers.DatePicker
 
             if (e.OldElement != null)
             {
-                Unsubscribe();
+                // Clean up
             }
 
-            if (e.NewElement != null)
+            
+            if (e.NewElement is Controls.DatePicker.DatePicker)
             {
-                if (e.NewElement is Controls.DatePicker.DatePicker datePicker)
-                {
-                    m_datePicker = datePicker;
-
-                    SubscribeToEvents();
-                    SaveDefaultValues();
-                    InitialChecks();
-                }
-            }
-        }
-
-        private void InitialChecks()
-        {
-            if (!m_datePicker.HasBorder)
-            {
+                // Initialize
                 TurnOffBorder();
             }
-        }
-
-        private void SaveDefaultValues()
-        {
-            m_defaultLayerBorderWith = Control.Layer.BorderWidth;
-            m_defaultBorderStyle = Control.BorderStyle;
-
-        }
-
-        private void Unsubscribe()
-        {
-            m_datePicker.PropertyChanged -= OnPropertyChanged;
-        }
-
-        private void OnPropertyChanged(object sender, PropertyChangedEventArgs e)
-        {
-            if (e.PropertyName.Equals(nameof(m_datePicker.HasBorder)))
-            {
-                ToggleBorder();
-            }
-        }
-
-        private void SubscribeToEvents()
-        {
-            m_datePicker.PropertyChanged += OnPropertyChanged;
-        }
-
-        private void ToggleBorder()
-        {
-            if (m_datePicker.HasBorder)
-            {
-                TurnOnBorder();
-            }
-            else
-            {
-                TurnOffBorder();
-            }
-        }
-
-        private void TurnOnBorder()
-        {
-            Control.Layer.BorderWidth = m_defaultLayerBorderWith;
-            Control.BorderStyle = m_defaultBorderStyle;
         }
 
         private void TurnOffBorder()

--- a/src/DIPS.Xamarin.UI/Controls/DatePicker/DatePicker.cs
+++ b/src/DIPS.Xamarin.UI/Controls/DatePicker/DatePicker.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using Xamarin.Forms;
 
 namespace DIPS.Xamarin.UI.Controls.DatePicker
@@ -9,22 +10,10 @@ namespace DIPS.Xamarin.UI.Controls.DatePicker
     public class DatePicker : global::Xamarin.Forms.DatePicker
     {
         /// <summary>
-        /// Bindale property for <see cref="HasBorder"/>
+        /// An obsolete property that was used to indicate wheter or not the date picker should have its native border turned on / off.
+        /// <remarks>This property is obsolete, and all date pickers will have its native border turned off now https://github.com/DIPSAS/DIPS.Xamarin.UI/issues/46</remarks>
         /// </summary>
-        public static readonly BindableProperty HasBorderProperty = BindableProperty.Create(
-            nameof(HasBorder),
-            typeof(bool),
-            typeof(DatePicker),
-            true);
-
-        /// <summary>
-        ///     Gets or sets a value that determines whether the datepicker should have it's native borders. This is a
-        ///     bindable property.
-        /// </summary>
-        public bool HasBorder
-        {
-            get => (bool)GetValue(HasBorderProperty);
-            set => SetValue(HasBorderProperty, value);
-        }
+        [Obsolete("Has border property is removed and no longer has any effect, The date picker should always remove it's native border. https://github.com/DIPSAS/DIPS.Xamarin.UI/issues/46")]
+        public bool HasBorder { get; set; }
     }
 }

--- a/src/Samples/DIPS.Xamarin.UI.Samples/Controls/DatePicker/DatePickerPage.xaml
+++ b/src/Samples/DIPS.Xamarin.UI.Samples/Controls/DatePicker/DatePickerPage.xaml
@@ -8,15 +8,6 @@
              x:Class="DIPS.Xamarin.UI.Samples.Controls.DatePicker.DatePickerPage"
              Title="DatePicker">
     <ContentPage.Content>
-        <StackLayout Orientation="Vertical">
-            <dxui:DatePicker HasBorder="{Binding Source={x:Reference hasBorderCheckBox}, Path=IsChecked}"/>
-            <StackLayout Orientation="Vertical">
-                <StackLayout Orientation="Horizontal">
-                    <Label Text="HasBorder"/>
-                    <CheckBox x:Name="hasBorderCheckBox" IsChecked="True"/>
-                </StackLayout>
-            </StackLayout>
-        </StackLayout>
-        
+        <dxui:DatePicker HorizontalOptions="CenterAndExpand" VerticalOptions="CenterAndExpand" />
     </ContentPage.Content>
 </ContentPage>


### PR DESCRIPTION
## Added / Fixed

### DatePicker
- Set `HasBorder` to obsolete and remove its toggle features in the platform specifics.
    - Fixes #46 

## Todo List

- [X] I have tested on an Android device.
- [X] I have tested on an iOS device.
- [X] I have added unit tests - None needed

>*Please add pictures / Gifs if possible*
>*Todo List can be checked by putting a `X` inside the brackets*
>*Remember to update our `wiki` after this PR is merged*
