### PR TITLE
Renamed `RaiseAfter` to `RaiseWhenSet`

### DIFF
--- a/src/DIPS.Xamarin.UI.sln
+++ b/src/DIPS.Xamarin.UI.sln
@@ -37,7 +37,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DIPS.Xamarin.Forms.IssuesRe
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DIPS.Xamarin.Forms.IssuesRepro.iOS", "IssuesRepro\DIPS.Xamarin.Forms.IssuesRepro\DIPS.Xamarin.Forms.IssuesRepro.iOS\DIPS.Xamarin.Forms.IssuesRepro.iOS.csproj", "{29CD206E-5D0E-4F8D-8065-4391A315DB9F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DIPS.Xamarin.Forms.IssuesRepro", "IssuesRepro\DIPS.Xamarin.Forms.IssuesRepro\DIPS.Xamarin.Forms.IssuesRepro\DIPS.Xamarin.Forms.IssuesRepro.csproj", "{C875B3E5-F312-4FA2-988D-E3B2927744A0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DIPS.Xamarin.Forms.IssuesRepro", "IssuesRepro\DIPS.Xamarin.Forms.IssuesRepro\DIPS.Xamarin.Forms.IssuesRepro\DIPS.Xamarin.Forms.IssuesRepro.csproj", "{C875B3E5-F312-4FA2-988D-E3B2927744A0}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/DIPS.Xamarin.UI/Controls/DatePicker/DatePicker.cs
+++ b/src/DIPS.Xamarin.UI/Controls/DatePicker/DatePicker.cs
@@ -13,7 +13,7 @@ namespace DIPS.Xamarin.UI.Controls.DatePicker
         /// An obsolete property that was used to indicate wheter or not the date picker should have its native border turned on / off.
         /// <remarks>This property is obsolete, and all date pickers will have its native border turned off now https://github.com/DIPSAS/DIPS.Xamarin.UI/issues/46</remarks>
         /// </summary>
-        [Obsolete("Has border property is removed and no longer has any effect, The date picker should always remove it's native border. https://github.com/DIPSAS/DIPS.Xamarin.UI/issues/46")]
+        [Obsolete("Marked as obsolete be the date picker should always remove it's native border. https://github.com/DIPSAS/DIPS.Xamarin.UI/issues/46")]
         public bool HasBorder { get; set; }
     }
 }

--- a/src/DIPS.Xamarin.UI/Extensions/PropertyChangedExtensions.cs
+++ b/src/DIPS.Xamarin.UI/Extensions/PropertyChangedExtensions.cs
@@ -23,7 +23,7 @@ namespace DIPS.Xamarin.UI.Extensions
         public static bool Set<S>(this INotifyPropertyChanged propertyChangedImplementation, ref S backingStore, S value, PropertyChangedEventHandler? propertyChanged, [CallerMemberName] string propertyName = "")
         {
 #pragma warning disable CS8604 // Disabled to be able to test RaiseAfter by calling Set, PropertyChanged should never actually be null in a Xamarin.Forms app and we do a null propagation check in RaiseAfter, so its safe to ignore
-            return propertyChanged.RaiseAfter(ref backingStore, value, propertyChangedImplementation, propertyName);
+            return propertyChanged.RaiseWhenSet(ref backingStore, value, propertyChangedImplementation, propertyName);
 #pragma warning restore CS8604
         }
 
@@ -76,7 +76,7 @@ namespace DIPS.Xamarin.UI.Extensions
                 propertyChanged.Raise(property, sender);
             }
         }
-
+            
         /// <summary>
         /// Sets a value to a backing field if it passes a equality check and notifies property changed.
         /// </summary>
@@ -89,7 +89,7 @@ namespace DIPS.Xamarin.UI.Extensions
         /// <remarks>This method does a equality check to see if the value has changed, if you need to notify property changed when the value has not changed, please use <see cref="Raise"/></remarks>
         /// <remarks>This extension method does not set the event `sender` when notifying property changed. This has not proven to a problem when we created the extension, but be aware of it if you end up with something strange. Set <see cref="sender"/> if you need to make sure that we send the event sender</remarks>
         /// <returns>A boolean value to indicate that the property changed has been invoked</returns>
-        public static bool RaiseAfter<S>(this PropertyChangedEventHandler propertyChanged, ref S backingStore, S value, object? sender = null, [CallerMemberName] string propertyName = "")
+        public static bool RaiseWhenSet<S>(this PropertyChangedEventHandler propertyChanged, ref S backingStore, S value, object? sender = null, [CallerMemberName] string propertyName = "")
         {
             if (EqualityComparer<S>.Default.Equals(backingStore, value))
                 return false;

--- a/src/DIPS.Xamarin.UI/Extensions/PropertyChangedExtensions.cs
+++ b/src/DIPS.Xamarin.UI/Extensions/PropertyChangedExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 
@@ -96,6 +97,29 @@ namespace DIPS.Xamarin.UI.Extensions
             backingStore = value;
             propertyChanged?.Raise(propertyName,sender);
             return true;
+        }
+
+        /// <summary>
+        /// Sets a value to a backing field if it passes a equality check and notifies property changed.
+        /// </summary>
+        /// <typeparam name="S">The type of the property</typeparam>
+        /// <param name="backingStore">The backing store that will hold the value of the property</param>
+        /// <param name="value">The new value that should be set</param>
+        /// <param name="propertyChanged">The property changed event handler that the propertyChangedImplementation holds</param>
+        /// <param name="sender">The event sender, optional because it is not required for the Xamarin.Forms view to react to a property changed</param>
+        /// <param name="propertyName">A nullable property name, if left empty it will pick the caller member name</param>
+        /// <remarks>This method does a equality check to see if the value has changed, if you need to notify property changed when the value has not changed, please use <see cref="Raise"/></remarks>
+        /// <remarks>This extension method does not set the event `sender` when notifying property changed. This has not proven to a problem when we created the extension, but be aware of it if you end up with something strange. Set <see cref="sender"/> if you need to make sure that we send the event sender</remarks>
+        /// <returns>A boolean value to indicate that the property changed has been invoked</returns>
+        [Obsolete("Marked as obsolete because it brings a bad fluent experience, please use RaiseWhenSet instead. This will be removed in future releases")]
+        public static bool RaiseAfter<S>(
+            this PropertyChangedEventHandler propertyChanged,
+            ref S backingStore,
+            S value,
+            object? sender = null,
+            [CallerMemberName] string propertyName = "")
+        {
+            return propertyChanged.RaiseWhenSet(ref backingStore, value, sender, propertyName);
         }
     }
 }

--- a/src/IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro.iOS/DIPS.Xamarin.Forms.IssuesRepro.iOS.csproj
+++ b/src/IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro.iOS/DIPS.Xamarin.Forms.IssuesRepro.iOS.csproj
@@ -127,6 +127,8 @@
     <ProjectReference Include="..\..\..\DIPS.Xamarin.UI.iOS\DIPS.Xamarin.UI.iOS.csproj">
       <Project>{a3258356-df96-427a-bd0f-cb4d18564ce1}</Project>
       <Name>DIPS.Xamarin.UI.iOS</Name>
+      <IsAppExtension>false</IsAppExtension>
+      <IsWatchApp>false</IsWatchApp>
     </ProjectReference>
     <ProjectReference Include="..\DIPS.Xamarin.Forms.IssuesRepro\DIPS.Xamarin.Forms.IssuesRepro.csproj">
       <Project>{56766DC9-DEEF-4C95-882B-4DB0D9D00C8A}</Project>

--- a/src/Samples/DIPS.Xamarin.UI.Samples/Extensions/PropertyChangedViewModel.cs
+++ b/src/Samples/DIPS.Xamarin.UI.Samples/Extensions/PropertyChangedViewModel.cs
@@ -26,7 +26,7 @@ namespace DIPS.Xamarin.UI.Samples.Extensions
                 this.Set(ref m_myFirstProperty, value, PropertyChanged);
 
                 //Alternate fluent version
-                PropertyChanged?.RaiseAfter(ref m_myFirstProperty, value);
+                PropertyChanged?.RaiseWhenSet(ref m_myFirstProperty, value);
             }
         }
 


### PR DESCRIPTION
## Added / Fixed

- Added `RaiseWhenSet` 
- Marke `RaiseAfter` as obsolete because it was confusing and not really fluent.

## Todo List

- [X] I have tested on an Android device.
- [X] I have tested on an iOS device.
- [X] I have added unit tests - Renamed

>*Please add pictures / Gifs if possible*
>*Todo List can be checked by putting a `X` inside the brackets*
>*Remember to update our `wiki` after this PR is merged*
