### PR TITLE
Made sure `LabelSize` support named font sizes.

### DIFF
--- a/src/DIPS.Xamarin.UI/Controls/DatePicker/DatePicker.xaml
+++ b/src/DIPS.Xamarin.UI/Controls/DatePicker/DatePicker.xaml
@@ -19,7 +19,6 @@
                     WidthRequest="{Binding Source={x:Reference DateLabel}, Path=Width}" />
         <Label x:Name="DateLabel"
                TextColor="{Binding Source={x:Reference codeBehind}, Path=LabelColor}"
-               FontSize="{Binding Source={x:Reference codeBehind}, Path=LabelSize}"
                InputTransparent="True"
                HorizontalOptions="{Binding Source={x:Reference codeBehind}, Path=HorizontalOptions}"
                VerticalOptions="{Binding Source={x:Reference codeBehind}, Path=VerticalOptions}" />

--- a/src/DIPS.Xamarin.UI/Controls/DatePicker/DatePicker.xaml.cs
+++ b/src/DIPS.Xamarin.UI/Controls/DatePicker/DatePicker.xaml.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Globalization;
 using DIPS.Xamarin.UI.Converters.ValueConverters;
+using DIPS.Xamarin.UI.InternalUtils;
 using Xamarin.Forms;
+using Xamarin.Forms.Internals;
 using Xamarin.Forms.Xaml;
 
 namespace DIPS.Xamarin.UI.Controls.DatePicker
@@ -58,7 +60,13 @@ namespace DIPS.Xamarin.UI.Controls.DatePicker
             nameof(LabelSize),
             typeof(double),
             typeof(DatePicker),
-            defaultValueCreator: DefaultLabelSizeCreator);
+            propertyChanged: OnLabelSizePropertyChanged);
+
+        private static void OnLabelSizePropertyChanged(BindableObject bindable, object oldvalue, object newvalue)
+        {
+            if (!(bindable is DatePicker datepicker)) return;
+            datepicker.DateLabel.FontSize = (double)newvalue;
+        }
 
         /// <inheritdoc />
         public DatePicker()
@@ -66,7 +74,7 @@ namespace DIPS.Xamarin.UI.Controls.DatePicker
             InitializeComponent();
         }
 
-        
+
         /// <summary>
         /// The date that the user picks from the date picker
         /// This is a bindable property
@@ -96,6 +104,7 @@ namespace DIPS.Xamarin.UI.Controls.DatePicker
         /// The label size of the label that the user can click to open the date picker
         /// This is a bindable property
         /// </summary>
+        [TypeConverter(typeof(LabelFontSizeTypeConverter))]
         public double LabelSize
         {
             get => (double)GetValue(LabelSizeProperty);
@@ -128,11 +137,6 @@ namespace DIPS.Xamarin.UI.Controls.DatePicker
             var formattedObject = new DateConverter() { Format = datePicker.Format }.Convert(datePicker.Date, null, null, CultureInfo.CurrentCulture);
             if (!(formattedObject is string formattedDate)) return;
             datePicker.DateLabel.Text = formattedDate;
-        }
-
-        private static object DefaultLabelSizeCreator(BindableObject bindable)
-        {
-            return Device.GetNamedSize(NamedSize.Body, typeof(Label));
         }
     }
 }

--- a/src/DIPS.Xamarin.UI/Controls/DatePicker/DatePicker.xaml.cs
+++ b/src/DIPS.Xamarin.UI/Controls/DatePicker/DatePicker.xaml.cs
@@ -146,5 +146,10 @@ namespace DIPS.Xamarin.UI.Controls.DatePicker
         {
             FormsDatePicker.Focus();
         }
+
+        /// <summary>
+        /// Boolean value to indicate if the date picker is open
+        /// </summary>
+        public bool IsOpen => FormsDatePicker.IsFocused;
     }
 }

--- a/src/DIPS.Xamarin.UI/Controls/DatePicker/DatePicker.xaml.cs
+++ b/src/DIPS.Xamarin.UI/Controls/DatePicker/DatePicker.xaml.cs
@@ -134,15 +134,7 @@ namespace DIPS.Xamarin.UI.Controls.DatePicker
         /// <summary>
         /// Opens the date picker
         /// </summary>
-        public void Open()
-        {
-            FormsDatePicker.Focus();
-        }
-
-        /// <summary>
-        /// Boolean value to indicate if the date picker is open
-        /// </summary>
-        public bool IsOpen => FormsDatePicker.IsFocused;
+        public void Open() => FormsDatePicker.Focus();
 
         private static void OnDateChanged(BindableObject bindable, object oldvalue, object newvalue)
         {

--- a/src/DIPS.Xamarin.UI/Controls/DatePicker/DatePicker.xaml.cs
+++ b/src/DIPS.Xamarin.UI/Controls/DatePicker/DatePicker.xaml.cs
@@ -74,7 +74,6 @@ namespace DIPS.Xamarin.UI.Controls.DatePicker
             InitializeComponent();
         }
 
-
         /// <summary>
         /// The date that the user picks from the date picker
         /// This is a bindable property
@@ -104,6 +103,7 @@ namespace DIPS.Xamarin.UI.Controls.DatePicker
         /// The label size of the label that the user can click to open the date picker
         /// This is a bindable property
         /// </summary>
+        /// <remarks>This support named font sizes <see href="https://docs.microsoft.com/en-us/xamarin/xamarin-forms/user-interface/text/fonts#named-font-sizes"/></remarks>
         [TypeConverter(typeof(LabelFontSizeTypeConverter))]
         public double LabelSize
         {
@@ -131,14 +131,6 @@ namespace DIPS.Xamarin.UI.Controls.DatePicker
             set => SetValue(MinimumDateProperty, value);
         }
 
-        private static void OnDateChanged(BindableObject bindable, object oldvalue, object newvalue)
-        {
-            if (!(bindable is DatePicker datePicker)) return;
-            var formattedObject = new DateConverter() { Format = datePicker.Format }.Convert(datePicker.Date, null, null, CultureInfo.CurrentCulture);
-            if (!(formattedObject is string formattedDate)) return;
-            datePicker.DateLabel.Text = formattedDate;
-        }
-
         /// <summary>
         /// Opens the date picker
         /// </summary>
@@ -151,5 +143,13 @@ namespace DIPS.Xamarin.UI.Controls.DatePicker
         /// Boolean value to indicate if the date picker is open
         /// </summary>
         public bool IsOpen => FormsDatePicker.IsFocused;
+
+        private static void OnDateChanged(BindableObject bindable, object oldvalue, object newvalue)
+        {
+            if (!(bindable is DatePicker datePicker)) return;
+            var formattedObject = new DateConverter() { Format = datePicker.Format }.Convert(datePicker.Date, null, null, CultureInfo.CurrentCulture);
+            if (!(formattedObject is string formattedDate)) return;
+            datePicker.DateLabel.Text = formattedDate;
+        }
     }
 }

--- a/src/DIPS.Xamarin.UI/Controls/DatePicker/DatePicker.xaml.cs
+++ b/src/DIPS.Xamarin.UI/Controls/DatePicker/DatePicker.xaml.cs
@@ -138,5 +138,13 @@ namespace DIPS.Xamarin.UI.Controls.DatePicker
             if (!(formattedObject is string formattedDate)) return;
             datePicker.DateLabel.Text = formattedDate;
         }
+
+        /// <summary>
+        /// Opens the date picker
+        /// </summary>
+        public void Open()
+        {
+            FormsDatePicker.Focus();
+        }
     }
 }

--- a/src/DIPS.Xamarin.UI/Controls/TimePicker/TimePicker.xaml
+++ b/src/DIPS.Xamarin.UI/Controls/TimePicker/TimePicker.xaml
@@ -11,10 +11,10 @@
     <Grid IsClippedToBounds="True">
         <TimePicker x:Name="FormsTimePicker"
                     Time="{Binding Source={x:Reference codeBehind}, Path=Time}"
-                    Margin="{Binding Source={x:Reference DateLabel}, Path=Height, Converter={ValueConverters:MultiplicationConverter Factor=-1}}"
+                    Margin="{Binding Source={x:Reference TimeLabel}, Path=Height, Converter={ValueConverters:MultiplicationConverter Factor=-1}}"
                     TextColor="Transparent"
-                    HeightRequest="{Binding Source={x:Reference DateLabel}, Path=Height}"
-                    WidthRequest="{Binding Source={x:Reference DateLabel}, Path=Width}" />
+                    HeightRequest="{Binding Source={x:Reference TimeLabel}, Path=Height}"
+                    WidthRequest="{Binding Source={x:Reference TimeLabel}, Path=Width}" />
         <Label x:Name="TimeLabel"
                Text="{Binding Source={x:Reference codeBehind}, Path=Time}"
                TextColor="{Binding Source={x:Reference codeBehind}, Path=LabelColor}"

--- a/src/DIPS.Xamarin.UI/Controls/TimePicker/TimePicker.xaml
+++ b/src/DIPS.Xamarin.UI/Controls/TimePicker/TimePicker.xaml
@@ -18,7 +18,6 @@
         <Label x:Name="DateLabel"
                Text="{Binding Source={x:Reference codeBehind}, Path=Time}"
                TextColor="{Binding Source={x:Reference codeBehind}, Path=LabelColor}"
-               FontSize="{Binding Source={x:Reference codeBehind}, Path=LabelSize}"
                InputTransparent="True"
                HorizontalOptions="{Binding Source={x:Reference codeBehind}, Path=HorizontalOptions}"
                VerticalOptions="{Binding Source={x:Reference codeBehind}, Path=VerticalOptions}" />

--- a/src/DIPS.Xamarin.UI/Controls/TimePicker/TimePicker.xaml
+++ b/src/DIPS.Xamarin.UI/Controls/TimePicker/TimePicker.xaml
@@ -9,13 +9,13 @@
              x:Class="DIPS.Xamarin.UI.Controls.TimePicker.TimePicker"
              x:Name="codeBehind">
     <Grid IsClippedToBounds="True">
-        <TimePicker x:Name="FormsDatePicker"
+        <TimePicker x:Name="FormsTimePicker"
                     Time="{Binding Source={x:Reference codeBehind}, Path=Time}"
                     Margin="{Binding Source={x:Reference DateLabel}, Path=Height, Converter={ValueConverters:MultiplicationConverter Factor=-1}}"
                     TextColor="Transparent"
                     HeightRequest="{Binding Source={x:Reference DateLabel}, Path=Height}"
                     WidthRequest="{Binding Source={x:Reference DateLabel}, Path=Width}" />
-        <Label x:Name="DateLabel"
+        <Label x:Name="TimeLabel"
                Text="{Binding Source={x:Reference codeBehind}, Path=Time}"
                TextColor="{Binding Source={x:Reference codeBehind}, Path=LabelColor}"
                InputTransparent="True"

--- a/src/DIPS.Xamarin.UI/Controls/TimePicker/TimePicker.xaml.cs
+++ b/src/DIPS.Xamarin.UI/Controls/TimePicker/TimePicker.xaml.cs
@@ -101,15 +101,7 @@ namespace DIPS.Xamarin.UI.Controls.TimePicker
         /// <summary>
         /// Opens the time picker
         /// </summary>
-        public void Open()
-        {
-            FormsTimePicker.Focus();
-        }
-
-        /// <summary>
-        /// Boolean value to indicate if the time picker is open
-        /// </summary>
-        public bool IsOpen => FormsTimePicker.IsFocused;
+        public void Open() => FormsTimePicker.Focus();
 
         private static void TimePropertyChanged(BindableObject bindable, object oldvalue, object newvalue)
         {

--- a/src/DIPS.Xamarin.UI/Controls/TimePicker/TimePicker.xaml.cs
+++ b/src/DIPS.Xamarin.UI/Controls/TimePicker/TimePicker.xaml.cs
@@ -74,6 +74,7 @@ namespace DIPS.Xamarin.UI.Controls.TimePicker
         /// The size of the label that the user clicks to chose a time
         /// This is a bindable property
         /// </summary>
+        /// <remarks>This support named font sizes <see href="https://docs.microsoft.com/en-us/xamarin/xamarin-forms/user-interface/text/fonts#named-font-sizes"/></remarks>
         [TypeConverter(typeof(LabelFontSizeTypeConverter))]
         public double LabelSize
         {
@@ -97,16 +98,6 @@ namespace DIPS.Xamarin.UI.Controls.TimePicker
             return new TimeSpan(now.Hour, now.Minute, now.Second);
         }
 
-        private static void TimePropertyChanged(BindableObject bindable, object oldvalue, object newvalue)
-        {
-            if (!(bindable is TimePicker timePicker))
-                return;
-            var formattedObject = new TimeConverter() { Format = timePicker.Format }.Convert(timePicker.Time, null, null, CultureInfo.CurrentCulture);
-            if (!(formattedObject is string formattedDate))
-                return;
-            timePicker.TimeLabel.Text = formattedDate;
-        }
-
         /// <summary>
         /// Opens the time picker
         /// </summary>
@@ -119,5 +110,15 @@ namespace DIPS.Xamarin.UI.Controls.TimePicker
         /// Boolean value to indicate if the time picker is open
         /// </summary>
         public bool IsOpen => FormsTimePicker.IsFocused;
+
+        private static void TimePropertyChanged(BindableObject bindable, object oldvalue, object newvalue)
+        {
+            if (!(bindable is TimePicker timePicker))
+                return;
+            var formattedObject = new TimeConverter() { Format = timePicker.Format }.Convert(timePicker.Time, null, null, CultureInfo.CurrentCulture);
+            if (!(formattedObject is string formattedDate))
+                return;
+            timePicker.TimeLabel.Text = formattedDate;
+        }
     }
 }

--- a/src/DIPS.Xamarin.UI/Controls/TimePicker/TimePicker.xaml.cs
+++ b/src/DIPS.Xamarin.UI/Controls/TimePicker/TimePicker.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Globalization;
 using DIPS.Xamarin.UI.Converters.ValueConverters;
+using DIPS.Xamarin.UI.InternalUtils;
 using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
@@ -40,7 +41,13 @@ namespace DIPS.Xamarin.UI.Controls.TimePicker
             nameof(LabelSize),
             typeof(double),
             typeof(TimePicker),
-            defaultValueCreator: DefaultLabelSizeCreator);
+            propertyChanged:OnLabelSizePropertyChanged);
+
+        private static void OnLabelSizePropertyChanged(BindableObject bindable, object oldvalue, object newvalue)
+        {
+            if (!(bindable is TimePicker timePicker)) return;
+            timePicker.DateLabel.FontSize = (double)newvalue;
+        }
 
         /// <inheritdoc />
         public TimePicker()
@@ -67,6 +74,7 @@ namespace DIPS.Xamarin.UI.Controls.TimePicker
         /// The size of the label that the user clicks to chose a time
         /// This is a bindable property
         /// </summary>
+        [TypeConverter(typeof(LabelFontSizeTypeConverter))]
         public double LabelSize
         {
             get => (double)GetValue(LabelSizeProperty);
@@ -97,11 +105,6 @@ namespace DIPS.Xamarin.UI.Controls.TimePicker
             if (!(formattedObject is string formattedDate))
                 return;
             timePicker.DateLabel.Text = formattedDate;
-        }
-
-        private static object DefaultLabelSizeCreator(BindableObject bindable)
-        {
-            return Device.GetNamedSize(NamedSize.Body, typeof(Label));
         }
     }
 }

--- a/src/DIPS.Xamarin.UI/Controls/TimePicker/TimePicker.xaml.cs
+++ b/src/DIPS.Xamarin.UI/Controls/TimePicker/TimePicker.xaml.cs
@@ -46,7 +46,7 @@ namespace DIPS.Xamarin.UI.Controls.TimePicker
         private static void OnLabelSizePropertyChanged(BindableObject bindable, object oldvalue, object newvalue)
         {
             if (!(bindable is TimePicker timePicker)) return;
-            timePicker.DateLabel.FontSize = (double)newvalue;
+            timePicker.TimeLabel.FontSize = (double)newvalue;
         }
 
         /// <inheritdoc />
@@ -104,7 +104,12 @@ namespace DIPS.Xamarin.UI.Controls.TimePicker
             var formattedObject = new TimeConverter() { Format = timePicker.Format }.Convert(timePicker.Time, null, null, CultureInfo.CurrentCulture);
             if (!(formattedObject is string formattedDate))
                 return;
-            timePicker.DateLabel.Text = formattedDate;
+            timePicker.TimeLabel.Text = formattedDate;
+        }
+
+        public void Open()
+        {
+            FormsTimePicker.Focus();
         }
     }
 }

--- a/src/DIPS.Xamarin.UI/Controls/TimePicker/TimePicker.xaml.cs
+++ b/src/DIPS.Xamarin.UI/Controls/TimePicker/TimePicker.xaml.cs
@@ -107,6 +107,9 @@ namespace DIPS.Xamarin.UI.Controls.TimePicker
             timePicker.TimeLabel.Text = formattedDate;
         }
 
+        /// <summary>
+        /// Opens the time picker
+        /// </summary>
         public void Open()
         {
             FormsTimePicker.Focus();

--- a/src/DIPS.Xamarin.UI/Controls/TimePicker/TimePicker.xaml.cs
+++ b/src/DIPS.Xamarin.UI/Controls/TimePicker/TimePicker.xaml.cs
@@ -114,5 +114,10 @@ namespace DIPS.Xamarin.UI.Controls.TimePicker
         {
             FormsTimePicker.Focus();
         }
+
+        /// <summary>
+        /// Boolean value to indicate if the time picker is open
+        /// </summary>
+        public bool IsOpen => FormsTimePicker.IsFocused;
     }
 }

--- a/src/DIPS.Xamarin.UI/InternalUtils/LabelFontSizeTypeConverter.cs
+++ b/src/DIPS.Xamarin.UI/InternalUtils/LabelFontSizeTypeConverter.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Globalization;
+using System.Text;
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+using TypeConverter = Xamarin.Forms.TypeConverter;
+
+namespace DIPS.Xamarin.UI.InternalUtils
+{
+    /// <summary>
+    /// A font size converter facade that makes sure that the font size type converter always runs as a label and returns the correct named size value every time
+    /// </summary>
+    [TypeConversion(typeof(double))]
+    public class LabelFontSizeTypeConverter : TypeConverter
+    {
+        private readonly FontSizeConverter m_fontSizeConverter;
+
+        /// <inheritdoc />
+        public LabelFontSizeTypeConverter()
+        {
+            m_fontSizeConverter = new FontSizeConverter();    
+        }
+
+        /// <inheritdoc />
+        public override object ConvertFromInvariantString(string value)
+        {
+            return m_fontSizeConverter.ConvertFromInvariantString(value);
+        }
+    }
+}

--- a/src/IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro.iOS/DIPS.Xamarin.Forms.IssuesRepro.iOS.csproj
+++ b/src/IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro.iOS/DIPS.Xamarin.Forms.IssuesRepro.iOS.csproj
@@ -47,7 +47,14 @@
     <MtouchArch>ARM64</MtouchArch>
     <CodesignKey>iPhone Developer</CodesignKey>
     <MtouchDebug>true</MtouchDebug>
-    <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
+    <CodesignEntitlements>
+    </CodesignEntitlements>
+    <MtouchLink>None</MtouchLink>
+    <MtouchInterpreter>-all</MtouchInterpreter>
+    <CodesignProvision>
+    </CodesignProvision>
+    <CodesignExtraArgs />
+    <CodesignResourceRules />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
     <DebugType>none</DebugType>

--- a/src/IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro.csproj
+++ b/src/IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro.csproj
@@ -17,5 +17,14 @@
     <EmbeddedResource Update="Github64\Github64.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
+    <EmbeddedResource Update="Github86\Github86.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="Github86\Github86.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </None>
   </ItemGroup>
 </Project>

--- a/src/IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/Github86/Github86.xaml
+++ b/src/IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/Github86/Github86.xaml
@@ -1,0 +1,76 @@
+﻿<?xml version="1.0"
+      encoding="utf-8"?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             x:Class="DIPS.Xamarin.Forms.IssuesRepro.Github86.Github86"
+             xmlns:dxui="http://dips.xamarin.ui.com"
+             xmlns:IssuesRepro="clr-namespace:DIPS.Xamarin.Forms.IssuesRepro;assembly=DIPS.Xamarin.Forms.IssuesRepro">
+
+    <StackLayout HorizontalOptions="Center"
+                 VerticalOptions="Center">
+        <StackLayout.Resources>
+            <Style TargetType="Label">
+                <Setter Property="HorizontalOptions"
+                        Value="Center" />
+                <Setter Property="VerticalOptions"
+                        Value="Center" />
+            </Style>
+            <Style TargetType="dxui:DatePicker">
+                <Setter Property="HorizontalOptions"
+                        Value="Center" />
+                <Setter Property="VerticalOptions"
+                        Value="Center" />
+            </Style>
+            <Style TargetType="dxui:TimePicker">
+                <Setter Property="HorizontalOptions"
+                        Value="Center" />
+                <Setter Property="VerticalOptions"
+                        Value="Center" />
+            </Style>
+        </StackLayout.Resources>
+        <Label Text="StandardLabel" FontSize="Title" />
+        <Label x:Name="standardLabel"
+               Text="1st Jan 1900"
+               FontSize="Default"
+        />
+        <Label FontSize="Default">
+            <Label.FormattedText>
+                <FormattedString>
+                    <Span Text="StandardLabel.LabelSize: " />
+                    <Span Text="{Binding Source={x:Reference standardLabel}, Path=FontSize}" />
+                </FormattedString>
+            </Label.FormattedText>
+        </Label>
+
+        <Label Text="DatePicker"
+               FontSize="Title" />
+        <dxui:DatePicker x:Name="datePicker"
+                         LabelSize="Default"/>
+        <Label>
+            <Label.FormattedText>
+                <FormattedString>
+                    <Span Text="DatePicker.LabelSize: " />
+                    <Span Text="{Binding Source={x:Reference datePicker}, Path=LabelSize}" />
+                </FormattedString>
+            </Label.FormattedText>
+        </Label>
+
+        <Label Text="TimePicker"
+               FontSize="Title"
+               Margin="0,20,0,0" />
+        <dxui:TimePicker x:Name="timePicker"
+                         LabelSize="Default"
+                         Time="0" />
+        <Label>
+            <Label.FormattedText>
+                <FormattedString>
+                    <Span Text="TimePicker.LabelSize: " />
+                    <Span Text="{Binding Source={x:Reference timePicker}, Path=LabelSize}" />
+                </FormattedString>
+            </Label.FormattedText>
+        </Label>
+    </StackLayout>
+</ContentPage>

--- a/src/IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/Github86/Github86.xaml.cs
+++ b/src/IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/Github86/Github86.xaml.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace DIPS.Xamarin.Forms.IssuesRepro.Github86
+{
+    [XamlCompilation(XamlCompilationOptions.Compile)]
+    public partial class Github86 : ContentPage
+    {
+        public Github86()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/src/IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/MainPage.xaml
+++ b/src/IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/MainPage.xaml
@@ -16,6 +16,9 @@
         <Button Text="Github issue 64"
                 Command="{Binding NavigationCommand}"
                 CommandParameter="64" />
+        <Button Text="Github issue 86"
+                Command="{Binding NavigationCommand}"
+                CommandParameter="86" />
     </StackLayout>
 
 </ContentPage>

--- a/src/IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/MainViewModel.cs
+++ b/src/IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/MainViewModel.cs
@@ -16,6 +16,8 @@ namespace DIPS.Xamarin.Forms.IssuesRepro
         {
             if (obj.Equals("64"))
                 Application.Current.MainPage.Navigation.PushAsync(new Github64.Github64());
+            if (obj.Equals("86"))
+                Application.Current.MainPage.Navigation.PushAsync(new Github86.Github86());
         }
     }
 }


### PR DESCRIPTION
## Added / Fixed

- Added reproduced bug page
- Added `LabelFontSizeTypeConverter` on `LabelSize` to make sure we handle name font sizes.
- Added `Open()` an `IsOpen` in order for our consumers to be able to open the pickers and to check it it is open.

## Todo List

- [X] I have tested on an Android device.
- [X] I have tested on an iOS device.
- [ ] I have added unit tests
    - None needed

## References
- Fixes #86 

>*Please add pictures / Gifs if possible*
>*Todo List can be checked by putting a `X` inside the brackets*
>*Remember to update our `wiki` after this PR is merged*
