### PR TITLE
Changed `MultiplicationConverter.Factor` to double

### DIFF
--- a/src/DIPS.Xamarin.UI/Converters/ValueConverters/BoolToObjectConverter.cs
+++ b/src/DIPS.Xamarin.UI/Converters/ValueConverters/BoolToObjectConverter.cs
@@ -30,7 +30,7 @@ namespace DIPS.Xamarin.UI.Converters.ValueConverters
         public object? Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
             if (!(value is bool inputValue)) throw new ArgumentException($"Input value has to be of type {nameof(Boolean)}");
-            if(TrueObject == null) throw new ArgumentException($"{nameof(TrueObject)} can not be null");
+            if (TrueObject == null) throw new ArgumentException($"{nameof(TrueObject)} can not be null");
             if(FalseObject == null) throw new ArgumentException($"{nameof(FalseObject)} can not be null");
             if (TrueObject.GetType() != FalseObject.GetType())
                 throw new ArgumentException($"{nameof(TrueObject)} has to be the same type as {FalseObject}");

--- a/src/DIPS.Xamarin.UI/Converters/ValueConverters/MultiplicationConverter.cs
+++ b/src/DIPS.Xamarin.UI/Converters/ValueConverters/MultiplicationConverter.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Numerics;
-using System.Text;
 using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
@@ -19,20 +16,17 @@ namespace DIPS.Xamarin.UI.Converters.ValueConverters
         /// <summary>
         /// The factor to multiply with
         /// </summary>
-        /// <remarks>This has to be number</remarks>
-        public object? Factor { get; set; }
+        public double? Factor { get; set; }
 
         /// <inheritdoc />
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
             if (value == null) throw new ArgumentException("Value is null");
-            if (Factor == null) throw new ArgumentException("Factor is null, it has to be a number");
+            if (Factor == null) throw new ArgumentException("Factor is null, it has to be a double");
             if (!double.TryParse(value.ToString(), out var number))
-                throw new InvalidOperationException("Value is not a number.");
-            if (!double.TryParse(Factor.ToString(), out var factor))
-                throw new InvalidOperationException("Value is not a number.");
+                throw new ArgumentException("Value is not a number");
 
-            return number * factor;
+            return number * Factor;
         }
 
         /// <inheritdoc />

--- a/src/Tests/DIPS.Xamarin.UI.Tests/Converters/ValueConverters/MultiplicationConverterTests.cs
+++ b/src/Tests/DIPS.Xamarin.UI.Tests/Converters/ValueConverters/MultiplicationConverterTests.cs
@@ -13,13 +13,13 @@ namespace DIPS.Xamarin.UI.Tests.Converters.ValueConverters
         [InlineData(1f, 2f, 2)]
         [InlineData(1, 2, 2)]
         [InlineData(1.0, 2.0, 2.0)]
-        [InlineData((ulong)1.0, (ulong)2, 2)]
-        [InlineData((uint)1, (uint)2, 2)]
-        [InlineData((long)1.0, (long)2.0, 2)]
-        [InlineData((ushort)1.0, (ushort)2.0, 2)]
-        [InlineData((short)1.0, (short)2.0, 2)]
-        [InlineData((byte)1.0, (byte)2.0, 2)]
-        public void Convert_WithValueAndFactor_CorrectMultiplication(object value, object factor, double expected)
+        [InlineData((ulong)1.0, 2, 2)]
+        [InlineData((uint)1, 2, 2)]
+        [InlineData((long)1.0, 2.0, 2)]
+        [InlineData((ushort)1.0, 2.0, 2)]
+        [InlineData((short)1.0, 2.0, 2)]
+        [InlineData((byte)1.0, 2.0, 2)]
+        public void Convert_WithValueAndFactor_CorrectMultiplication(object value, double factor, double expected)
         {
             m_multiplicationConverter.Factor = factor;
             var actual = m_multiplicationConverter.Convert(value, null, null, null);
@@ -31,7 +31,7 @@ namespace DIPS.Xamarin.UI.Tests.Converters.ValueConverters
         public void Convert_Decimal_CorrectMultiplication()
         {
             var expected = 2;
-            m_multiplicationConverter.Factor = 2.0M;
+            m_multiplicationConverter.Factor = 2.0;
             var actual = m_multiplicationConverter.Convert(1.0M, null, null, null);
             actual.Should().Be(expected);
         }


### PR DESCRIPTION
## Added / Fixed

- Changed `MultiplicationConverter.Factor` to double
    - This is to prevent potential culture variances of the value. If the converter properties has no strong type, XAML will send the property as a string.

## Todo List

- [X] I have tested on an Android device.
- [X] I have tested on an iOS device.
- [X] I have added unit tests

>*Please add pictures / Gifs if possible*
>*Todo List can be checked by putting a `X` inside the brackets*
>*Remember to update our `wiki` after this PR is merged*
