### PR TITLE
Fixed sizing of radiobuttongroup

### DIFF
--- a/src/DIPS.Xamarin.UI/Controls/RadioButtonGroup/RadioButtonGroup.xaml
+++ b/src/DIPS.Xamarin.UI/Controls/RadioButtonGroup/RadioButtonGroup.xaml
@@ -5,6 +5,11 @@
              xmlns:d="http://xamarin.com/schemas/2014/forms/design"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d"
-             x:Class="DIPS.Xamarin.UI.Controls.RadioButtonGroup.RadioButtonGroup">
-    <StackLayout x:Name="container" Orientation="Vertical"/>
+             x:Class="DIPS.Xamarin.UI.Controls.RadioButtonGroup.RadioButtonGroup"
+             x:Name="codeBehind">
+    <StackLayout x:Name="container"
+                 Orientation="Vertical"
+                 HorizontalOptions="{Binding Source={x:Reference codeBehind}, Path=HorizontalOptions}"
+                 VerticalOptions="{Binding Source={x:Reference codeBehind}, Path=VerticalOptions}"
+                 />
 </ContentView>

--- a/src/DIPS.Xamarin.UI/Internal/Xaml/RadioButton.xaml
+++ b/src/DIPS.Xamarin.UI/Internal/Xaml/RadioButton.xaml
@@ -14,14 +14,9 @@
         <Thickness x:Key="spacing"
                    Left="10" />
     </ContentView.Resources>
-    <Grid BindingContext="{Binding Source={x:Reference codeBehind}}"
-          Padding="{StaticResource spacing}"
-          ColumnSpacing="0">
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="Auto" />
-            <ColumnDefinition Width="*" />
-        </Grid.ColumnDefinitions>
-
+    <StackLayout BindingContext="{Binding Source={x:Reference codeBehind}}"
+                 Padding="{StaticResource spacing}"
+                 Orientation="Horizontal">
         <Grid VerticalOptions="Center"
               HorizontalOptions="Center">
             <Button x:Name="outerButton"
@@ -40,12 +35,11 @@
         </Grid>
 
         <Label x:Name="label"
-               Grid.Column="1"
                HeightRequest="{Binding Source={x:Reference outerButton}, Path=HeightRequest}"
                VerticalOptions="Center"
                Text="{Binding Text}"
                FontSize="Body"
                InputTransparent="True"
                Margin="{StaticResource spacing}" />
-    </Grid>
+    </StackLayout>
 </ContentView>

--- a/src/IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro.csproj
+++ b/src/IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro.csproj
@@ -14,6 +14,15 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Update="Github112\Github112.xaml.cs">
+      <DependentUpon>Github112.xaml</DependentUpon>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Update="Github112\Github112.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
     <EmbeddedResource Update="Github64\Github64.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>

--- a/src/IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/Github112/Github112.xaml
+++ b/src/IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/Github112/Github112.xaml
@@ -8,6 +8,19 @@
              mc:Ignorable="d"
              x:Class="DIPS.Xamarin.Forms.IssuesRepro.Github112.Github112">
     <StackLayout>
+        <dxui:RadioButtonGroup Grid.Row="0"
+                               Margin="0,5,0,0"
+                               HorizontalOptions="{Binding Source={x:Reference HorizontalOptions},Path=SelectedItem}"
+                               VerticalOptions="{Binding Source={x:Reference VerticalOptions},Path=SelectedItem}">
+            <dxui:RadioButtonGroup.ItemsSource>
+                <x:Array Type="{x:Type x:String}">
+                    <x:String>First item</x:String>
+                    <x:String>Second item</x:String>
+                    <x:String>Third item</x:String>
+                </x:Array>
+            </dxui:RadioButtonGroup.ItemsSource>
+        </dxui:RadioButtonGroup>
+
         <StackLayout Orientation="Horizontal">
             <Label Text="HorizontalOptions" />
             <Picker x:Name="HorizontalOptions">
@@ -43,18 +56,5 @@
                 </Picker.ItemsSource>
             </Picker>
         </StackLayout>
-
-        <dxui:RadioButtonGroup Grid.Row="0"
-                               Margin="0,5,0,0"
-                               HorizontalOptions="{Binding Source={x:Reference HorizontalOptions},Path=SelectedItem}"
-                               VerticalOptions="{Binding Source={x:Reference VerticalOptions},Path=SelectedItem}">
-            <dxui:RadioButtonGroup.ItemsSource>
-                <x:Array Type="{x:Type x:String}">
-                    <x:String>First item</x:String>
-                    <x:String>Second item</x:String>
-                    <x:String>Third item</x:String>
-                </x:Array>
-            </dxui:RadioButtonGroup.ItemsSource>
-        </dxui:RadioButtonGroup>
     </StackLayout>
 </ContentPage>

--- a/src/IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/Github112/Github112.xaml
+++ b/src/IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/Github112/Github112.xaml
@@ -1,0 +1,60 @@
+﻿<?xml version="1.0"
+      encoding="utf-8"?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:dxui="http://dips.xamarin.ui.com"
+             mc:Ignorable="d"
+             x:Class="DIPS.Xamarin.Forms.IssuesRepro.Github112.Github112">
+    <StackLayout>
+        <StackLayout Orientation="Horizontal">
+            <Label Text="HorizontalOptions" />
+            <Picker x:Name="HorizontalOptions">
+                <Picker.ItemsSource>
+                    <x:Array Type="{x:Type LayoutOptions}">
+                        <LayoutOptions>Start</LayoutOptions>
+                        <LayoutOptions>StartAndExpand</LayoutOptions>
+                        <LayoutOptions>Center</LayoutOptions>
+                        <LayoutOptions>CenterAndExpand</LayoutOptions>
+                        <LayoutOptions>End</LayoutOptions>
+                        <LayoutOptions>EndAndExpand</LayoutOptions>
+                        <LayoutOptions>Fill</LayoutOptions>
+                        <LayoutOptions>FillAndExpand</LayoutOptions>
+                    </x:Array>
+                </Picker.ItemsSource>
+            </Picker>
+        </StackLayout>
+
+        <StackLayout Orientation="Horizontal">
+            <Label Text="VerticalOptions" />
+            <Picker x:Name="VerticalOptions">
+                <Picker.ItemsSource>
+                    <x:Array Type="{x:Type LayoutOptions}">
+                        <LayoutOptions>Start</LayoutOptions>
+                        <LayoutOptions>StartAndExpand</LayoutOptions>
+                        <LayoutOptions>Center</LayoutOptions>
+                        <LayoutOptions>CenterAndExpand</LayoutOptions>
+                        <LayoutOptions>End</LayoutOptions>
+                        <LayoutOptions>EndAndExpand</LayoutOptions>
+                        <LayoutOptions>Fill</LayoutOptions>
+                        <LayoutOptions>FillAndExpand</LayoutOptions>
+                    </x:Array>
+                </Picker.ItemsSource>
+            </Picker>
+        </StackLayout>
+
+        <dxui:RadioButtonGroup Grid.Row="0"
+                               Margin="0,5,0,0"
+                               HorizontalOptions="{Binding Source={x:Reference HorizontalOptions},Path=SelectedItem}"
+                               VerticalOptions="{Binding Source={x:Reference VerticalOptions},Path=SelectedItem}">
+            <dxui:RadioButtonGroup.ItemsSource>
+                <x:Array Type="{x:Type x:String}">
+                    <x:String>First item</x:String>
+                    <x:String>Second item</x:String>
+                    <x:String>Third item</x:String>
+                </x:Array>
+            </dxui:RadioButtonGroup.ItemsSource>
+        </dxui:RadioButtonGroup>
+    </StackLayout>
+</ContentPage>

--- a/src/IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/Github112/Github112.xaml.cs
+++ b/src/IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/Github112/Github112.xaml.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace DIPS.Xamarin.Forms.IssuesRepro.Github112
+{
+    [XamlCompilation(XamlCompilationOptions.Compile)]
+    public partial class Github112 : ContentPage
+    {
+        public Github112()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/src/IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/MainPage.xaml
+++ b/src/IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/MainPage.xaml
@@ -18,7 +18,10 @@
                 CommandParameter="64" />
         <Button Text="Github issue 86"
                 Command="{Binding NavigationCommand}"
-                CommandParameter="86" />
+                CommandParameter="86" /> 
+        <Button Text="Github issue 112"
+                Command="{Binding NavigationCommand}"
+                CommandParameter="112" />
     </StackLayout>
 
 </ContentPage>

--- a/src/IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/MainViewModel.cs
+++ b/src/IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/MainViewModel.cs
@@ -18,6 +18,8 @@ namespace DIPS.Xamarin.Forms.IssuesRepro
                 Application.Current.MainPage.Navigation.PushAsync(new Github64.Github64());
             if (obj.Equals("86"))
                 Application.Current.MainPage.Navigation.PushAsync(new Github86.Github86());
+            if (obj.Equals("112"))
+                Application.Current.MainPage.Navigation.PushAsync(new Github112.Github112());
         }
     }
 }


### PR DESCRIPTION
## Added / Fixed

- Removed inner grid and made sure the radiobuttongroups is using its parents alignment options

## Todo List

## References
- Closes #112 

- [X] I have tested on an Android device.
- [X] I have tested on an iOS device.
- [ ] I have added unit tests

>*Please add pictures / Gifs if possible*
>*Todo List can be checked by putting a `X` inside the brackets*
>*Remember to update our `wiki` after this PR is merged*
