### PR TITLE
Added IsClippedToBounds to ModalityLayout

### DIFF
--- a/src/DIPS.Xamarin.UI/Controls/Modality/ModalityLayout.xaml
+++ b/src/DIPS.Xamarin.UI/Controls/Modality/ModalityLayout.xaml
@@ -1,7 +1,8 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <ContentView xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="DIPS.Xamarin.UI.Controls.Modality.ModalityLayout">
+             x:Class="DIPS.Xamarin.UI.Controls.Modality.ModalityLayout"
+             IsClippedToBounds="True">
     <RelativeLayout x:Name="relativeLayout"
                     ChildRemoved="OnChildRemoved"/>
 </ContentView>


### PR DESCRIPTION
## Added / Fixed

- Added `IsClippedToBounds=True` to `ModalityLayout`
    - The (and other components) inside of the modalitylayout should not be visible outside of the `ModalityLayout`.

## Todo List

- [X] I have tested on an Android device.
- [X] I have tested on an iOS device.
- [ ] I have added unit tests

>*Please add pictures / Gifs if possible*
>*Todo List can be checked by putting a `X` inside the brackets*
>*Remember to update our `wiki` after this PR is merged*
