### PR TITLE
Added reference area to trendgraphs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -343,3 +343,4 @@ DIPS.Xamarin.UI*.xml
 Resource.designer.cs
 src/DIPS.Xamarin.UI.Android/Resources/Resource.designer.cs
 src/Samples/DIPS.Xamarin.UI.Samples.Android/Resources/Resource.designer.cs
+src/IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro.Android/Resources/Resource.designer.cs

--- a/src/DIPS.Xamarin.UI/Controls/TrendGraph/TrendGraph.xaml.cs
+++ b/src/DIPS.Xamarin.UI/Controls/TrendGraph/TrendGraph.xaml.cs
@@ -84,7 +84,7 @@ namespace DIPS.Xamarin.UI.Controls.TrendGraph
             var color = GraphColor;
             if(UpperBound != null && value > UpperBound.Value || LowerBound != null && value < LowerBound.Value)
             {
-                color = ReferenceColor;
+                color = OutOfBoundsColor;
             }
 
             var itemHeight = value.CalculateRelativePosition(MinValue, MaxValue);
@@ -130,7 +130,7 @@ namespace DIPS.Xamarin.UI.Controls.TrendGraph
         /// <summary>
         /// Color to draw the graph with if the value is outside the reference area.
         /// </summary>
-        public Color ReferenceColor { get; set; } = Color.Red;
+        public Color OutOfBoundsColor { get; set; } = Color.Red;
 
 
         /// <summary>

--- a/src/DIPS.Xamarin.UI/Controls/TrendGraph/TrendGraph.xaml.cs
+++ b/src/DIPS.Xamarin.UI/Controls/TrendGraph/TrendGraph.xaml.cs
@@ -80,7 +80,14 @@ namespace DIPS.Xamarin.UI.Controls.TrendGraph
 
         private void DrawGraph(double x, object item, double widthPerItem)
         {
-            var itemHeight = item.ExtractDouble(ValueMemberPath, MinValue).CalculateRelativePosition(MinValue, MaxValue);
+            var value = item.ExtractDouble(ValueMemberPath, MinValue);
+            var color = GraphColor;
+            if(UpperBound != null && value > UpperBound.Value || LowerBound != null && value < LowerBound.Value)
+            {
+                color = ReferenceColor;
+            }
+
+            var itemHeight = value.CalculateRelativePosition(MinValue, MaxValue);
             var backFrame = CreateBoxView(GraphBackgroundColor);
 
             graphContainer.Children.Add(backFrame,
@@ -89,7 +96,7 @@ namespace DIPS.Xamarin.UI.Controls.TrendGraph
                 widthConstraint: Constraint.RelativeToParent(r => widthPerItem),
                 heightConstraint: Constraint.RelativeToParent(r => r.Height));
 
-            graphContainer.Children.Add(CreateBoxView(GraphColor),
+            graphContainer.Children.Add(CreateBoxView(color),
                 xConstraint: Constraint.RelativeToParent(r => backFrame.X),
                 yConstraint: Constraint.RelativeToParent(r => backFrame.Y + backFrame.Height - (itemHeight * backFrame.Height)),
                 widthConstraint: Constraint.RelativeToParent(r => backFrame.Width),
@@ -111,34 +118,20 @@ namespace DIPS.Xamarin.UI.Controls.TrendGraph
         }
 
         /// <summary>
-        ///  <see cref="GraphColor" />
-        /// </summary>
-        public static readonly BindableProperty GraphColorProperty =
-            BindableProperty.Create(nameof(GraphColor), typeof(Color), typeof(TrendGraph), Color.FromHex("#a26eba"), propertyChanged: OnAnyPropertyChanged);
-
-        /// <summary>
         /// Color of each graph
         /// </summary>
-        public Color GraphColor
-        {
-            get { return (Color)GetValue(GraphColorProperty); }
-            set { SetValue(GraphColorProperty, value); }
-        }
-
-        /// <summary>
-        ///  <see cref="GraphBackgroundColor" />
-        /// </summary>
-        public static readonly BindableProperty GraphBackgroundColorProperty =
-            BindableProperty.Create(nameof(GraphBackgroundColor), typeof(Color), typeof(TrendGraph), Color.FromHex("#edf3f4"), propertyChanged: OnAnyPropertyChanged);
+        public Color GraphColor { get; set; } = Color.FromHex("#a26eba");
 
         /// <summary>
         /// Background color of each graph
         /// </summary>
-        public Color GraphBackgroundColor
-        {
-            get { return (Color)GetValue(GraphBackgroundColorProperty); }
-            set { SetValue(GraphBackgroundColorProperty, value); }
-        }
+        public Color GraphBackgroundColor { get; set; } = Color.FromHex("#edf3f4");
+
+        /// <summary>
+        /// Color to draw the graph with if the value is outside the reference area.
+        /// </summary>
+        public Color ReferenceColor { get; set; } = Color.Red;
+
 
         /// <summary>
         ///  <see cref="MaxValue" />
@@ -213,6 +206,36 @@ namespace DIPS.Xamarin.UI.Controls.TrendGraph
         {
             get { return (string)GetValue(ValueMemberPathProperty); }
             set { SetValue(ValueMemberPathProperty, value); }
+        }
+
+        /// <summary>
+        ///  <see cref="LowerBound" />
+        /// </summary>
+        public static readonly BindableProperty LowerBoundProperty =
+            BindableProperty.Create(nameof(LowerBound), typeof(double?), typeof(TrendGraph), null, propertyChanged: OnAnyPropertyChanged);
+
+        /// <summary>
+        /// Lower bound of the trend values
+        /// </summary>
+        public double? LowerBound
+        {
+            get { return (double?)GetValue(LowerBoundProperty); }
+            set { SetValue(LowerBoundProperty, value); }
+        }
+
+        /// <summary>
+        ///  <see cref="UpperBound" />
+        /// </summary>
+        public static readonly BindableProperty UpperBoundProperty =
+            BindableProperty.Create(nameof(UpperBound), typeof(double?), typeof(TrendGraph), null, propertyChanged: OnAnyPropertyChanged);
+
+        /// <summary>
+        /// Upper bound of the trend values
+        /// </summary>
+        public double? UpperBound
+        {
+            get { return (double?)GetValue(UpperBoundProperty); }
+            set { SetValue(UpperBoundProperty, value); }
         }
     }
 }

--- a/src/Samples/DIPS.Xamarin.UI.Samples/Controls/TrendGraph/TrendGraphPage.xaml
+++ b/src/Samples/DIPS.Xamarin.UI.Samples/Controls/TrendGraph/TrendGraphPage.xaml
@@ -1,87 +1,102 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
-<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="DIPS.Xamarin.UI.Samples.Controls.TrendGraph.TrendGraphPage"
-             xmlns:dxui="http://dips.xamarin.ui.com">
-    <StackLayout Orientation="Vertical"
-                 HorizontalOptions="FillAndExpand">
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<ContentPage
+    x:Class="DIPS.Xamarin.UI.Samples.Controls.TrendGraph.TrendGraphPage"
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:dxui="http://dips.xamarin.ui.com">
+    <StackLayout HorizontalOptions="FillAndExpand" Orientation="Vertical">
         <Grid>
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="50"/>
-                <ColumnDefinition/>
+                <ColumnDefinition Width="50" />
+                <ColumnDefinition />
             </Grid.ColumnDefinitions>
-            <dxui:TrendGraph MaxValue="{Binding MaxValue}"
-                             MinValue="0"
-                             Margin="5"
-                             GraphMargin="1"
-                             ItemsSource="{Binding TrendItems}"
-                             ValueMemberPath="Value"/>
-            <Label Margin="5"
-                   Grid.Column="1"
-                   VerticalOptions="Center"
-                   Text="Normal trend bar bound to an observable collection"/>
+            <dxui:TrendGraph
+                Margin="5"
+                GraphMargin="1"
+                ItemsSource="{Binding TrendItems}"
+                LowerBound="1"
+                MaxValue="{Binding MaxValue}"
+                MinValue="0"
+                ValueMemberPath="Value" />
+            <Label
+                Grid.Column="1"
+                Margin="5"
+                Text="Normal trend bar bound to an observable collection"
+                VerticalOptions="Center" />
         </Grid>
 
         <Grid>
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="50"/>
-                <ColumnDefinition/>
+                <ColumnDefinition Width="50" />
+                <ColumnDefinition />
             </Grid.ColumnDefinitions>
-            <dxui:TrendGraph MaxValue="10"
-                             MinValue="0"
-                             Margin="5"
-                             ItemsSource="{Binding TrendItems2}"/>
-            <Label Margin="5"
-                   Grid.Column="1"
-                   VerticalOptions="Center"
-                   Text="Bound to double list"/>
+            <dxui:TrendGraph
+                Margin="5"
+                ItemsSource="{Binding TrendItems2}"
+                LowerBound="{Binding LowerBound}"
+                MaxValue="10"
+                MinValue="0"
+                UpperBound="{Binding UpperBound}" />
+            <Label
+                Grid.Column="1"
+                Margin="5"
+                Text="Bound to double list"
+                VerticalOptions="Center" />
         </Grid>
 
 
         <Grid>
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="50"/>
-                <ColumnDefinition/>
+                <ColumnDefinition Width="50" />
+                <ColumnDefinition />
             </Grid.ColumnDefinitions>
-            <dxui:TrendGraph MaxValue="4"
-                             MinValue="2"
-                             Margin="5"
-                             GraphColor="Red"
-                             GraphBackgroundColor="LightGray"
-                             ItemsSource="{Binding TrendItems3}"/>
-            <Label Margin="5"
-                   Grid.Column="1"
-                   VerticalOptions="Center"
-                   Text="Bound to int list with min value at 2"/>
+            <dxui:TrendGraph
+                Margin="5"
+                GraphBackgroundColor="LightGray"
+                GraphColor="Red"
+                ItemsSource="{Binding TrendItems3}"
+                LowerBound="3"
+                MaxValue="6"
+                MinValue="2"
+                UpperBound="4" />
+            <Label
+                Grid.Column="1"
+                Margin="5"
+                Text="Bound to int list with min value at 2"
+                VerticalOptions="Center" />
         </Grid>
 
         <Grid>
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="50"/>
-                <ColumnDefinition/>
+                <ColumnDefinition Width="50" />
+                <ColumnDefinition />
             </Grid.ColumnDefinitions>
-            <dxui:TrendGraph MaxValue="10"
-                             MinValue="0"
-                             Margin="5"
-                             ItemsSource="{Binding TrendItems4}"/>
-            <Label Margin="5"
-                   Grid.Column="1"
-                   VerticalOptions="Center"
-                   Text="One less item"/>
+            <dxui:TrendGraph
+                Margin="5"
+                ItemsSource="{Binding TrendItems4}"
+                MaxValue="10"
+                MinValue="0" />
+            <Label
+                Grid.Column="1"
+                Margin="5"
+                Text="One less item"
+                VerticalOptions="Center" />
         </Grid>
 
         <Grid>
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="50"/>
-                <ColumnDefinition/>
+                <ColumnDefinition Width="50" />
+                <ColumnDefinition />
             </Grid.ColumnDefinitions>
-            <dxui:TrendGraph Margin="5"
-                             ValueMemberPath="Value"
-                             ItemsSource="{Binding TrendItems5}"/>
-            <Button Margin="5"
-                    Grid.Column="1"
-                    Command="{Binding AddGraphItemCommand}"
-                    Text="Add item"/>
+            <dxui:TrendGraph
+                Margin="5"
+                ItemsSource="{Binding TrendItems5}"
+                ValueMemberPath="Value" />
+            <Button
+                Grid.Column="1"
+                Margin="5"
+                Command="{Binding AddGraphItemCommand}"
+                Text="Add item" />
         </Grid>
     </StackLayout>
 </ContentPage>

--- a/src/Samples/DIPS.Xamarin.UI.Samples/Controls/TrendGraph/TrendGraphPage.xaml.cs
+++ b/src/Samples/DIPS.Xamarin.UI.Samples/Controls/TrendGraph/TrendGraphPage.xaml.cs
@@ -31,9 +31,12 @@ namespace DIPS.Xamarin.UI.Samples.Controls.TrendGraph
 
         public int MaxValue { get => maxValue; set => this.Set(ref maxValue, value, PropertyChanged); }
 
-        public List<double> TrendItems2 { get; } = new List<double> { 5, 3, 10 };
+        public List<double> TrendItems2 { get; } = new List<double> { 9, 7.1, 5 };
 
         public int[] TrendItems3 { get; } = { 3, 3, 3 };
+
+        public double UpperBound => 7;
+        public double LowerBound => 4;
 
         public List<double> TrendItems4 { get; } = new List<double> { 6, 8 };
 


### PR DESCRIPTION
## Added / Fixed
Users can now indicate if a value should get a different color if the value is above or below some reference area.

```xml
            <dxui:TrendGraph
                ItemsSource="{Binding TrendItems}"
                LowerBound="{Binding LowerBound}"
                UpperBound="{Binding UpperBound}" />

```

## Todo List

- [x] I have tested on an Android device.
- [x] I have tested on an iOS device.

<img width="58" alt="image" src="https://user-images.githubusercontent.com/1519936/74244253-68edf800-4ce1-11ea-8ab7-8b4213c19134.png">
