### PR TITLE
Bug -  added null checks to Config in SlidableLayout

### DIFF
--- a/src/DIPS.Xamarin.UI/Controls/Slidable/SlidableContentLayout.cs
+++ b/src/DIPS.Xamarin.UI/Controls/Slidable/SlidableContentLayout.cs
@@ -35,6 +35,11 @@ namespace DIPS.Xamarin.UI.Controls.Slidable
         /// <param name="index"></param>
         protected override void OnScrolled(double index)
         {
+            if (Config == null)
+            {
+                return;
+            }
+            
             lock (m_lock)
             {
                 base.OnScrolled(index);
@@ -50,7 +55,7 @@ namespace DIPS.Xamarin.UI.Controls.Slidable
                 for (var i = index - itemCount; i <= index + itemCount; i++)
                 {
                     var iIndex = (int)Math.Floor(i);
-                    if (iIndex < Config?.MinValue || iIndex > Config?.MaxValue) continue;
+                    if (iIndex < Config.MinValue || iIndex > Config.MaxValue) continue;
                     var view = CreateItem(iIndex);
 
                     UpdateSelected(view, selectedIndex == iIndex);

--- a/src/DIPS.Xamarin.UI/Controls/Slidable/SlidableContentLayout.cs
+++ b/src/DIPS.Xamarin.UI/Controls/Slidable/SlidableContentLayout.cs
@@ -50,11 +50,11 @@ namespace DIPS.Xamarin.UI.Controls.Slidable
                 for (var i = index - itemCount; i <= index + itemCount; i++)
                 {
                     var iIndex = (int)Math.Floor(i);
-                    if (iIndex < Config.MinValue || iIndex > Config.MaxValue) continue;
+                    if (iIndex < Config?.MinValue || iIndex > Config?.MaxValue) continue;
                     var view = CreateItem(iIndex);
 
                     UpdateSelected(view, selectedIndex == iIndex);
-
+                    
                     if (ScaleDown)
                     {
                         var dist = (Math.Abs(index - iIndex) / itemCount);

--- a/src/DIPS.Xamarin.UI/Controls/Slidable/SlidableLayout.cs
+++ b/src/DIPS.Xamarin.UI/Controls/Slidable/SlidableLayout.cs
@@ -64,6 +64,11 @@ namespace DIPS.Xamarin.UI.Controls.Slidable
                 return;
             }
 
+            if (Config == null)
+            {
+                return;
+            }
+
             var currentId = e.GestureId;
             if (!(m_lastId == SlideProperties.HoldId || !SlideProperties.IsHeld || currentId == m_lastId))
             {
@@ -78,7 +83,7 @@ namespace DIPS.Xamarin.UI.Controls.Slidable
 
             var currentPos = m_startSlideLocation - e.TotalX;
             m_lastId = currentId;
-            var index = Math.Max(Config?.MinValue ?? int.MinValue - 0.45, Math.Min(Config?.MaxValue ?? int.MaxValue + 0.45, CalculateIndex(currentPos)));
+            var index = Math.Max(Config.MinValue - 0.45, Math.Min(Config.MaxValue + 0.45, CalculateIndex(currentPos)));
 
             if (e.StatusType == GestureStatus.Completed || e.StatusType == GestureStatus.Canceled)
             {
@@ -98,8 +103,8 @@ namespace DIPS.Xamarin.UI.Controls.Slidable
                 Device.StartTimer(TimeSpan.FromMilliseconds(20), () => // ~40 fps
                 {
                     if (currentId != SlideProperties.HoldId) return false;
-                    m_accelerator.Min = Config?.MinValue - 0.45;
-                    m_accelerator.Max = Config?.MaxValue + 0.45;
+                    m_accelerator.Min = Config.MinValue - 0.45;
+                    m_accelerator.Max = Config.MaxValue + 0.45;
                     var next = m_accelerator.GetValue(out bool isDone);
                     index = next;
                     if (SlideProperties.IsHeld) return false;
@@ -221,8 +226,7 @@ namespace DIPS.Xamarin.UI.Controls.Slidable
         public static readonly BindableProperty ConfigProperty = BindableProperty.Create(
             nameof(Config),
             typeof(SliderConfig),
-            typeof(SlidableLayout),
-            defaultValue: new SliderConfig(int.MinValue, int.MaxValue));
+            typeof(SlidableLayout));
         
         /// <summary>
         /// Configuration indicating max and min values of this layout. 

--- a/src/DIPS.Xamarin.UI/Controls/Slidable/SlidableLayout.cs
+++ b/src/DIPS.Xamarin.UI/Controls/Slidable/SlidableLayout.cs
@@ -29,7 +29,7 @@ namespace DIPS.Xamarin.UI.Controls.Slidable
             Margin = 0;
             HorizontalOptions = LayoutOptions.FillAndExpand;
             VerticalOptions = LayoutOptions.FillAndExpand;
-            Config = new SliderConfig(int.MinValue, int.MaxValue);
+            //Config = new SliderConfig(int.MinValue, int.MaxValue);
             m_rec = new PanGestureRecognizer();
             GestureRecognizers.Add(m_rec);
             m_rec.PanUpdated += Rec_PanUpdated;
@@ -221,7 +221,8 @@ namespace DIPS.Xamarin.UI.Controls.Slidable
         public static readonly BindableProperty ConfigProperty = BindableProperty.Create(
             nameof(Config),
             typeof(SliderConfig),
-            typeof(SlidableLayout));
+            typeof(SlidableLayout),
+            defaultValue: new SliderConfig(int.MinValue, int.MaxValue));
 
         /// <summary>
         /// Configuration indicating max and min values of this layout. 

--- a/src/DIPS.Xamarin.UI/Controls/Slidable/SlidableLayout.cs
+++ b/src/DIPS.Xamarin.UI/Controls/Slidable/SlidableLayout.cs
@@ -29,7 +29,7 @@ namespace DIPS.Xamarin.UI.Controls.Slidable
             Margin = 0;
             HorizontalOptions = LayoutOptions.FillAndExpand;
             VerticalOptions = LayoutOptions.FillAndExpand;
-            //Config = new SliderConfig(int.MinValue, int.MaxValue);
+            Config = new SliderConfig(int.MinValue, int.MaxValue);
             m_rec = new PanGestureRecognizer();
             GestureRecognizers.Add(m_rec);
             m_rec.PanUpdated += Rec_PanUpdated;
@@ -78,7 +78,7 @@ namespace DIPS.Xamarin.UI.Controls.Slidable
 
             var currentPos = m_startSlideLocation - e.TotalX;
             m_lastId = currentId;
-            var index = Math.Max(Config.MinValue - 0.45, Math.Min(Config.MaxValue + 0.45, CalculateIndex(currentPos)));
+            var index = Math.Max(Config?.MinValue ?? int.MinValue - 0.45, Math.Min(Config?.MaxValue ?? int.MaxValue + 0.45, CalculateIndex(currentPos)));
 
             if (e.StatusType == GestureStatus.Completed || e.StatusType == GestureStatus.Canceled)
             {
@@ -98,8 +98,8 @@ namespace DIPS.Xamarin.UI.Controls.Slidable
                 Device.StartTimer(TimeSpan.FromMilliseconds(20), () => // ~40 fps
                 {
                     if (currentId != SlideProperties.HoldId) return false;
-                    m_accelerator.Min = Config.MinValue - 0.45;
-                    m_accelerator.Max = Config.MaxValue + 0.45;
+                    m_accelerator.Min = Config?.MinValue - 0.45;
+                    m_accelerator.Max = Config?.MaxValue + 0.45;
                     var next = m_accelerator.GetValue(out bool isDone);
                     index = next;
                     if (SlideProperties.IsHeld) return false;
@@ -223,7 +223,7 @@ namespace DIPS.Xamarin.UI.Controls.Slidable
             typeof(SliderConfig),
             typeof(SlidableLayout),
             defaultValue: new SliderConfig(int.MinValue, int.MaxValue));
-
+        
         /// <summary>
         /// Configuration indicating max and min values of this layout. 
         /// </summary>


### PR DESCRIPTION
## Added / Fixed

- Added default value to `Config` property in `SlidableLayout`, and null checks where `Config` is used. 

## Todo List

- [ ] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have added unit tests

>*Please add pictures / Gifs if possible*
>*Todo List can be checked by putting a `X` inside the brackets*
>*Remember to update our `wiki` after this PR is merged*
