### PR TITLE
Added the possibility of turn off tapping the overlay for modalities

### DIFF
--- a/src/DIPS.Xamarin.UI.sln
+++ b/src/DIPS.Xamarin.UI.sln
@@ -108,6 +108,7 @@ Global
 		{5D1BB5EC-52D3-4784-B20B-C4B022A496D0}.Debug|Any CPU.ActiveCfg = Debug|iPhone
 		{5D1BB5EC-52D3-4784-B20B-C4B022A496D0}.Debug|iPhone.ActiveCfg = Debug|iPhone
 		{5D1BB5EC-52D3-4784-B20B-C4B022A496D0}.Debug|iPhone.Build.0 = Debug|iPhone
+		{5D1BB5EC-52D3-4784-B20B-C4B022A496D0}.Debug|iPhone.Deploy.0 = Debug|iPhone
 		{5D1BB5EC-52D3-4784-B20B-C4B022A496D0}.Debug|iPhoneSimulator.ActiveCfg = Debug|iPhoneSimulator
 		{5D1BB5EC-52D3-4784-B20B-C4B022A496D0}.Debug|iPhoneSimulator.Build.0 = Debug|iPhoneSimulator
 		{5D1BB5EC-52D3-4784-B20B-C4B022A496D0}.Release|Any CPU.ActiveCfg = Release|iPhone
@@ -160,6 +161,7 @@ Global
 		{29CD206E-5D0E-4F8D-8065-4391A315DB9F}.Debug|Any CPU.ActiveCfg = Debug|iPhone
 		{29CD206E-5D0E-4F8D-8065-4391A315DB9F}.Debug|iPhone.ActiveCfg = Debug|iPhone
 		{29CD206E-5D0E-4F8D-8065-4391A315DB9F}.Debug|iPhone.Build.0 = Debug|iPhone
+		{29CD206E-5D0E-4F8D-8065-4391A315DB9F}.Debug|iPhone.Deploy.0 = Debug|iPhone
 		{29CD206E-5D0E-4F8D-8065-4391A315DB9F}.Debug|iPhoneSimulator.ActiveCfg = Debug|iPhoneSimulator
 		{29CD206E-5D0E-4F8D-8065-4391A315DB9F}.Debug|iPhoneSimulator.Build.0 = Debug|iPhoneSimulator
 		{29CD206E-5D0E-4F8D-8065-4391A315DB9F}.Release|Any CPU.ActiveCfg = Release|iPhone

--- a/src/DIPS.Xamarin.UI/Controls/FloatingActionMenu/FloatingActionMenuBehaviour.cs
+++ b/src/DIPS.Xamarin.UI/Controls/FloatingActionMenu/FloatingActionMenuBehaviour.cs
@@ -192,23 +192,23 @@ namespace DIPS.Xamarin.UI.Controls.FloatingActionMenu
         }
 
         /// <summary>
-        /// <see cref="ShouldCloseOnOverlayTapped"/>
+        /// <see cref="CloseOnOverlayTapped"/>
         /// </summary>
-        public static readonly BindableProperty ShouldCloseOnOverlayTappedProperty = BindableProperty.Create(nameof(ShouldCloseOnOverlayTapped), typeof(bool), typeof(FloatingActionMenuBehaviour), true, propertyChanged: OnShouldCloseOnOverlayTappedPropertyChanged);
+        public static readonly BindableProperty CloseOnOverlayTappedProperty = BindableProperty.Create(nameof(CloseOnOverlayTapped), typeof(bool), typeof(FloatingActionMenuBehaviour), true, propertyChanged: OnCloseOnOverlayTappedPropertyChanged);
 
-        private static void OnShouldCloseOnOverlayTappedPropertyChanged(BindableObject bindable, object oldvalue, object newvalue)
+        private static void OnCloseOnOverlayTappedPropertyChanged(BindableObject bindable, object oldvalue, object newvalue)
         {
             if (!(bindable is FloatingActionMenuBehaviour floatingActionMenuBehaviour)) return;
             if (!(bool.TryParse(newvalue.ToString(), out var newBoolValue))) return;
             if (floatingActionMenuBehaviour.m_floatingActionMenu == null) return;
-            floatingActionMenuBehaviour.m_floatingActionMenu.ShouldCloseOnOverlayTapped = newBoolValue;
+            floatingActionMenuBehaviour.m_floatingActionMenu.CloseOnOverlayTapped = newBoolValue;
         }
 
-        /// <see cref="IModalityHandler.ShouldCloseOnOverlayTapped"/>
-        public bool ShouldCloseOnOverlayTapped
+        /// <see cref="IModalityHandler.CloseOnOverlayTapped"/>
+        public bool CloseOnOverlayTapped
         {
-            get => (bool)GetValue(ShouldCloseOnOverlayTappedProperty);
-            set => SetValue(ShouldCloseOnOverlayTappedProperty, value);
+            get => (bool)GetValue(CloseOnOverlayTappedProperty);
+            set => SetValue(CloseOnOverlayTappedProperty, value);
         }
 
         private static void IsOpenPropertyChanged(BindableObject bindable, object oldvalue, object newvalue)

--- a/src/DIPS.Xamarin.UI/Controls/FloatingActionMenu/FloatingActionMenuBehaviour.cs
+++ b/src/DIPS.Xamarin.UI/Controls/FloatingActionMenu/FloatingActionMenuBehaviour.cs
@@ -191,6 +191,26 @@ namespace DIPS.Xamarin.UI.Controls.FloatingActionMenu
             set => SetValue(ExpandButtonFontSizeProperty, value);
         }
 
+        /// <summary>
+        /// <see cref="ShouldCloseOnOverlayTapped"/>
+        /// </summary>
+        public static readonly BindableProperty ShouldCloseOnOverlayTappedProperty = BindableProperty.Create(nameof(ShouldCloseOnOverlayTapped), typeof(bool), typeof(FloatingActionMenuBehaviour), true, propertyChanged: OnShouldCloseOnOverlayTappedPropertyChanged);
+
+        private static void OnShouldCloseOnOverlayTappedPropertyChanged(BindableObject bindable, object oldvalue, object newvalue)
+        {
+            if (!(bindable is FloatingActionMenuBehaviour floatingActionMenuBehaviour)) return;
+            if (!(bool.TryParse(newvalue.ToString(), out var newBoolValue))) return;
+            if (floatingActionMenuBehaviour.m_floatingActionMenu == null) return;
+            floatingActionMenuBehaviour.m_floatingActionMenu.ShouldCloseOnOverlayTapped = newBoolValue;
+        }
+
+        /// <see cref="IModalityHandler.ShouldCloseOnOverlayTapped"/>
+        public bool ShouldCloseOnOverlayTapped
+        {
+            get => (bool)GetValue(ShouldCloseOnOverlayTappedProperty);
+            set => SetValue(ShouldCloseOnOverlayTappedProperty, value);
+        }
+
         private static void IsOpenPropertyChanged(BindableObject bindable, object oldvalue, object newvalue)
         {
             if (bindable is FloatingActionMenuBehaviour menuBehaviour)

--- a/src/DIPS.Xamarin.UI/Controls/Modality/IModalityHandler.cs
+++ b/src/DIPS.Xamarin.UI/Controls/Modality/IModalityHandler.cs
@@ -6,25 +6,30 @@ using System.Threading.Tasks;
 namespace DIPS.Xamarin.UI.Controls.Modality
 {
     /// <summary>
-    /// An interface to communicate between the modality layout and a modality component
+    /// An interface to communicate between the modality layout and a modality component.
     /// </summary>
     public interface IModalityHandler
     {
         /// <summary>
-        /// Method that gets invoked when the user clicks the overlay and wants to hide the modal component
+        /// Method that gets invoked when the user clicks the overlay and wants to hide the modal component.
         /// </summary>
         void Hide();
 
         /// <summary>
-        /// Task that should be ran before removal of the current modal component
+        /// Task that should be ran before removal of the current modal component.
         /// </summary>
         /// <returns></returns>
         Task BeforeRemoval();
 
         /// <summary>
-        /// Task that should be ran after removal of the current modal component
+        /// Task that should be ran after removal of the current modal component.
         /// </summary>
         /// <returns></returns>
         Task AfterRemoval();
+
+        /// <summary>
+        /// Determines if the modality component should close when the overlay is tapped.
+        /// </summary>
+        bool ShouldCloseOnOverlayTapped { get; set; }
     }
 }

--- a/src/DIPS.Xamarin.UI/Controls/Modality/IModalityHandler.cs
+++ b/src/DIPS.Xamarin.UI/Controls/Modality/IModalityHandler.cs
@@ -30,6 +30,6 @@ namespace DIPS.Xamarin.UI.Controls.Modality
         /// <summary>
         /// Determines if the modality component should close when the overlay is tapped.
         /// </summary>
-        bool ShouldCloseOnOverlayTapped { get; set; }
+        bool CloseOnOverlayTapped { get; set; }
     }
 }

--- a/src/DIPS.Xamarin.UI/Controls/Modality/ModalityLayout.xaml.cs
+++ b/src/DIPS.Xamarin.UI/Controls/Modality/ModalityLayout.xaml.cs
@@ -72,19 +72,19 @@ namespace DIPS.Xamarin.UI.Controls.Modality
         }
 
         /// <summary>
-        /// <see cref="ShouldCloseModalitiesOnOverlayTapped"/>
+        /// <see cref="CloseModalitiesOnOverlayTapped"/>
         /// </summary>
-        public static readonly BindableProperty ShouldCloseModalitiesOnOverlayTappedProperty = BindableProperty.Create(nameof(ShouldCloseModalitiesOnOverlayTapped), typeof(bool), typeof(ModalityLayout), true);
+        public static readonly BindableProperty CloseModalitiesOnOverlayTappedProperty = BindableProperty.Create(nameof(CloseModalitiesOnOverlayTapped), typeof(bool), typeof(ModalityLayout), true);
 
         /// <summary>
         /// Determines if modalities in this modality layout should close when the overlay is tapped.
         /// This is a bindable property.
         /// </summary>
         /// <remarks>Default is true</remarks>
-        public bool ShouldCloseModalitiesOnOverlayTapped
+        public bool CloseModalitiesOnOverlayTapped
         {
-            get => (bool)GetValue(ShouldCloseModalitiesOnOverlayTappedProperty);
-            set => SetValue(ShouldCloseModalitiesOnOverlayTappedProperty, value);
+            get => (bool)GetValue(CloseModalitiesOnOverlayTappedProperty);
+            set => SetValue(CloseModalitiesOnOverlayTappedProperty, value);
         }
 
 
@@ -138,8 +138,8 @@ namespace DIPS.Xamarin.UI.Controls.Modality
             var overlayFrame = new Frame { BackgroundColor = OverlayColor, IsVisible = true, Opacity = 0.0 };
             var tappedCommand = new Command(
                 () => m_closeModalityRecognizer.Command.Execute(null),
-                () => CurrentShowingModalityLayout != null && CurrentShowingModalityLayout.ShouldCloseOnOverlayTapped &&
-                      ShouldCloseModalitiesOnOverlayTapped);
+                () => CurrentShowingModalityLayout != null && CurrentShowingModalityLayout.CloseOnOverlayTapped &&
+                      CloseModalitiesOnOverlayTapped);
             overlayFrame.GestureRecognizers.Add(new TapGestureRecognizer() { Command = tappedCommand });
 
             return overlayFrame;

--- a/src/DIPS.Xamarin.UI/Controls/Modality/ModalityLayout.xaml.cs
+++ b/src/DIPS.Xamarin.UI/Controls/Modality/ModalityLayout.xaml.cs
@@ -53,6 +53,7 @@ namespace DIPS.Xamarin.UI.Controls.Modality
 
         /// <summary>
         ///     Main Content of the layout. This is routed from the Content property, so you don't have to use it.
+        ///     This is a bindable property.
         /// </summary>
         public View MainContent
         {
@@ -62,12 +63,30 @@ namespace DIPS.Xamarin.UI.Controls.Modality
 
         /// <summary>
         ///     The color of the overlay when a modality component is showing
+        ///     This is a bindable property.
         /// </summary>
         public Color OverlayColor
         {
             get => (Color)GetValue(OverlayColorProperty);
             set => SetValue(OverlayColorProperty, value);
         }
+
+        /// <summary>
+        /// <see cref="ShouldCloseModalitiesOnOverlayTapped"/>
+        /// </summary>
+        public static readonly BindableProperty ShouldCloseModalitiesOnOverlayTappedProperty = BindableProperty.Create(nameof(ShouldCloseModalitiesOnOverlayTapped), typeof(bool), typeof(ModalityLayout), true);
+
+        /// <summary>
+        /// Determines if modalities in this modality layout should close when the overlay is tapped.
+        /// This is a bindable property.
+        /// </summary>
+        /// <remarks>Default is true</remarks>
+        public bool ShouldCloseModalitiesOnOverlayTapped
+        {
+            get => (bool)GetValue(ShouldCloseModalitiesOnOverlayTappedProperty);
+            set => SetValue(ShouldCloseModalitiesOnOverlayTappedProperty, value);
+        }
+
 
         private static void OnMainContentPropertyChanged(BindableObject bindable, object oldvalue, object newvalue)
         {
@@ -111,7 +130,15 @@ namespace DIPS.Xamarin.UI.Controls.Modality
 
         private void HideCurrentShowingModality()
         {
-            CurrentShowingModalityLayout?.Hide();
+            if(CurrentShowingModalityLayout == null) return;
+            if (CurrentShowingModalityLayout.ShouldCloseOnOverlayTapped)
+            {
+                if (ShouldCloseModalitiesOnOverlayTapped)
+                {
+                    CurrentShowingModalityLayout?.Hide();
+                }
+            }
+                
         }
 
         private Frame CreateOverlay()

--- a/src/DIPS.Xamarin.UI/Controls/Modality/ModalityLayout.xaml.cs
+++ b/src/DIPS.Xamarin.UI/Controls/Modality/ModalityLayout.xaml.cs
@@ -130,22 +130,18 @@ namespace DIPS.Xamarin.UI.Controls.Modality
 
         private void HideCurrentShowingModality()
         {
-            if(CurrentShowingModalityLayout == null) return;
-            if (CurrentShowingModalityLayout.ShouldCloseOnOverlayTapped)
-            {
-                if (ShouldCloseModalitiesOnOverlayTapped)
-                {
-                    CurrentShowingModalityLayout?.Hide();
-                }
-            }
-                
+            CurrentShowingModalityLayout?.Hide();
         }
 
         private Frame CreateOverlay()
         {
             var overlayFrame = new Frame { BackgroundColor = OverlayColor, IsVisible = true, Opacity = 0.0 };
+            var tappedCommand = new Command(
+                () => m_closeModalityRecognizer.Command.Execute(null),
+                () => CurrentShowingModalityLayout != null && CurrentShowingModalityLayout.ShouldCloseOnOverlayTapped &&
+                      ShouldCloseModalitiesOnOverlayTapped);
+            overlayFrame.GestureRecognizers.Add(new TapGestureRecognizer() { Command = tappedCommand });
 
-            overlayFrame.GestureRecognizers.Add(m_closeModalityRecognizer);
             return overlayFrame;
         }
 

--- a/src/DIPS.Xamarin.UI/Controls/Popup/PopupBehavior.cs
+++ b/src/DIPS.Xamarin.UI/Controls/Popup/PopupBehavior.cs
@@ -114,15 +114,15 @@ namespace DIPS.Xamarin.UI.Controls.Popup
         public Task AfterRemoval() => Task.CompletedTask;
 
         /// <summary>
-        /// <see cref="ShouldCloseOnOverlayTapped"/>
+        /// <see cref="CloseOnOverlayTapped"/>
         /// </summary>
-        public static readonly BindableProperty ShouldCloseOnOverlayTappedProperty = BindableProperty.Create(nameof(ShouldCloseOnOverlayTapped), typeof(bool), typeof(PopupBehavior), true);
+        public static readonly BindableProperty CloseOnOverlayTappedProperty = BindableProperty.Create(nameof(CloseOnOverlayTapped), typeof(bool), typeof(PopupBehavior), true);
 
         /// <inheritdoc cref=""/>
-        public bool ShouldCloseOnOverlayTapped
+        public bool CloseOnOverlayTapped
         {
-            get => (bool)GetValue(ShouldCloseOnOverlayTappedProperty);
-            set => SetValue(ShouldCloseOnOverlayTappedProperty, value);
+            get => (bool)GetValue(CloseOnOverlayTappedProperty);
+            set => SetValue(CloseOnOverlayTappedProperty, value);
         }
 
         /// <summary>

--- a/src/DIPS.Xamarin.UI/Controls/Popup/PopupBehavior.cs
+++ b/src/DIPS.Xamarin.UI/Controls/Popup/PopupBehavior.cs
@@ -114,6 +114,18 @@ namespace DIPS.Xamarin.UI.Controls.Popup
         public Task AfterRemoval() => Task.CompletedTask;
 
         /// <summary>
+        /// <see cref="ShouldCloseOnOverlayTapped"/>
+        /// </summary>
+        public static readonly BindableProperty ShouldCloseOnOverlayTappedProperty = BindableProperty.Create(nameof(ShouldCloseOnOverlayTapped), typeof(bool), typeof(PopupBehavior), true);
+
+        /// <inheritdoc cref=""/>
+        public bool ShouldCloseOnOverlayTapped
+        {
+            get => (bool)GetValue(ShouldCloseOnOverlayTappedProperty);
+            set => SetValue(ShouldCloseOnOverlayTappedProperty, value);
+        }
+
+        /// <summary>
         ///     Handels attaching to item.
         /// </summary>
         /// <param name="bindable"></param>

--- a/src/DIPS.Xamarin.UI/Controls/Sheet/SheetBehavior.cs
+++ b/src/DIPS.Xamarin.UI/Controls/Sheet/SheetBehavior.cs
@@ -478,17 +478,17 @@ namespace DIPS.Xamarin.UI.Controls.Sheet
         }
 
         /// <summary>
-        /// <see cref="ShouldCloseOnOverlayTapped"/>
+        /// <see cref="CloseOnOverlayTapped"/>
         /// </summary>
-        public static readonly BindableProperty ShouldCloseOnOverlayTappedProperty = BindableProperty.Create(nameof(ShouldCloseOnOverlayTapped), typeof(bool), typeof(SheetBehavior), true);
+        public static readonly BindableProperty CloseOnOverlayTappedProperty = BindableProperty.Create(nameof(CloseOnOverlayTapped), typeof(bool), typeof(SheetBehavior), true);
 
         /// <summary>
         /// <inheritdoc />
         /// </summary>
-        public bool ShouldCloseOnOverlayTapped
+        public bool CloseOnOverlayTapped
         {
-            get => (bool)GetValue(ShouldCloseOnOverlayTappedProperty);
-            set => SetValue(ShouldCloseOnOverlayTappedProperty, value);
+            get => (bool)GetValue(CloseOnOverlayTappedProperty);
+            set => SetValue(CloseOnOverlayTappedProperty, value);
         }
 
         private static async void OnPositionPropertyChanged(BindableObject bindable, object oldvalue, object newvalue)

--- a/src/DIPS.Xamarin.UI/Controls/Sheet/SheetBehavior.cs
+++ b/src/DIPS.Xamarin.UI/Controls/Sheet/SheetBehavior.cs
@@ -477,6 +477,20 @@ namespace DIPS.Xamarin.UI.Controls.Sheet
             return Task.CompletedTask;
         }
 
+        /// <summary>
+        /// <see cref="ShouldCloseOnOverlayTapped"/>
+        /// </summary>
+        public static readonly BindableProperty ShouldCloseOnOverlayTappedProperty = BindableProperty.Create(nameof(ShouldCloseOnOverlayTapped), typeof(bool), typeof(SheetBehavior), true);
+
+        /// <summary>
+        /// <inheritdoc />
+        /// </summary>
+        public bool ShouldCloseOnOverlayTapped
+        {
+            get => (bool)GetValue(ShouldCloseOnOverlayTappedProperty);
+            set => SetValue(ShouldCloseOnOverlayTappedProperty, value);
+        }
+
         private static async void OnPositionPropertyChanged(BindableObject bindable, object oldvalue, object newvalue)
         {
             if (!(bindable is SheetBehavior sheetBehavior)) return;

--- a/src/DIPS.Xamarin.UI/Internal/Xaml/FloatingActionMenu.xaml.cs
+++ b/src/DIPS.Xamarin.UI/Internal/Xaml/FloatingActionMenu.xaml.cs
@@ -162,5 +162,17 @@ namespace DIPS.Xamarin.UI.Internal.Xaml
             return Task.CompletedTask;
 
         }
+
+        /// <summary>
+        /// <see cref="ShouldCloseOnOverlayTapped"/>
+        /// </summary>
+        public static readonly BindableProperty ShouldCloseOnOverlayTappedProperty = BindableProperty.Create(nameof(ShouldCloseOnOverlayTapped), typeof(bool), typeof(FloatingActionMenu), true);
+
+        /// <inheritdoc />
+        public bool ShouldCloseOnOverlayTapped
+        {
+            get => (bool)GetValue(ShouldCloseOnOverlayTappedProperty);
+            set => SetValue(ShouldCloseOnOverlayTappedProperty, value);
+        }
     }
 }

--- a/src/DIPS.Xamarin.UI/Internal/Xaml/FloatingActionMenu.xaml.cs
+++ b/src/DIPS.Xamarin.UI/Internal/Xaml/FloatingActionMenu.xaml.cs
@@ -164,15 +164,15 @@ namespace DIPS.Xamarin.UI.Internal.Xaml
         }
 
         /// <summary>
-        /// <see cref="ShouldCloseOnOverlayTapped"/>
+        /// <see cref="CloseOnOverlayTapped"/>
         /// </summary>
-        public static readonly BindableProperty ShouldCloseOnOverlayTappedProperty = BindableProperty.Create(nameof(ShouldCloseOnOverlayTapped), typeof(bool), typeof(FloatingActionMenu), true);
+        public static readonly BindableProperty CloseOnOverlayTappedProperty = BindableProperty.Create(nameof(CloseOnOverlayTapped), typeof(bool), typeof(FloatingActionMenu), true);
 
         /// <inheritdoc />
-        public bool ShouldCloseOnOverlayTapped
+        public bool CloseOnOverlayTapped
         {
-            get => (bool)GetValue(ShouldCloseOnOverlayTappedProperty);
-            set => SetValue(ShouldCloseOnOverlayTappedProperty, value);
+            get => (bool)GetValue(CloseOnOverlayTappedProperty);
+            set => SetValue(CloseOnOverlayTappedProperty, value);
         }
     }
 }

--- a/src/Samples/DIPS.Xamarin.UI.Samples/Controls/FloatingActionMenu/FloatingActionMenuPage.xaml
+++ b/src/Samples/DIPS.Xamarin.UI.Samples/Controls/FloatingActionMenu/FloatingActionMenuPage.xaml
@@ -23,6 +23,7 @@
                                               ExpandButtonTextColor="Azure"
                                               XPosition=".9"
                                               YPosition=".95"
+                                              ShouldCloseOnOverlayTapped="{Binding Source={x:Reference shouldCloseOnTappedOverlayCheckbox}, Path=IsChecked}"
                                               IsVisible="{Binding Source={x:Reference toggleVisibilityCheckbox}, Path=IsChecked}">
                 <dxui:MenuButton BackgroundColor="LightSeaGreen"
                                  Text="A"
@@ -59,6 +60,11 @@
             <StackLayout Orientation="Horizontal">
                 <Label Text="Toggle visibility" VerticalTextAlignment="Center"/>
                 <CheckBox x:Name="toggleVisibilityCheckbox"
+                          IsChecked="True" />
+            </StackLayout>
+            <StackLayout Orientation="Horizontal">
+                <Label Text="Should close on tapped overlay" VerticalTextAlignment="Center"/>
+                <CheckBox x:Name="shouldCloseOnTappedOverlayCheckbox"
                           IsChecked="True" />
             </StackLayout>
         </StackLayout>

--- a/src/Samples/DIPS.Xamarin.UI.Samples/Controls/FloatingActionMenu/FloatingActionMenuPage.xaml
+++ b/src/Samples/DIPS.Xamarin.UI.Samples/Controls/FloatingActionMenu/FloatingActionMenuPage.xaml
@@ -23,7 +23,7 @@
                                               ExpandButtonTextColor="Azure"
                                               XPosition=".9"
                                               YPosition=".95"
-                                              ShouldCloseOnOverlayTapped="{Binding Source={x:Reference shouldCloseOnTappedOverlayCheckbox}, Path=IsChecked}"
+                                              CloseOnOverlayTapped="{Binding Source={x:Reference shouldCloseOnTappedOverlayCheckbox}, Path=IsChecked}"
                                               IsVisible="{Binding Source={x:Reference toggleVisibilityCheckbox}, Path=IsChecked}">
                 <dxui:MenuButton BackgroundColor="LightSeaGreen"
                                  Text="A"

--- a/src/Samples/DIPS.Xamarin.UI.Samples/Controls/Popup/PopupPage.xaml
+++ b/src/Samples/DIPS.Xamarin.UI.Samples/Controls/Popup/PopupPage.xaml
@@ -57,7 +57,7 @@
             </Frame>
         </DataTemplate>
     </ContentPage.Resources>
-    <dxui:ModalityLayout>
+    <dxui:ModalityLayout CloseModalitiesOnOverlayTapped="False">
         <Grid BackgroundColor="WhiteSmoke">
             <Grid>
                 <Grid.RowDefinitions>

--- a/src/Samples/DIPS.Xamarin.UI.Samples/Controls/Sheet/SheetPage.xaml
+++ b/src/Samples/DIPS.Xamarin.UI.Samples/Controls/Sheet/SheetPage.xaml
@@ -36,6 +36,7 @@
                                     MinPosition="{Binding MinPosition}"
                                     MaxPosition="{Binding MaxPosition}"
                                     BindingContextFactory="{Binding SheetViewModelFactory}"
+                                    ShouldCloseOnOverlayTapped="{Binding Source={x:Reference ShouldCloseOnOverlayTappedCheckbox}, Path=IsChecked}"
                                     OnPositionChanged="SheetBehavior_OnOnPositionChanged">
                     <StackLayout>
                         <Label Text="{Binding Source={x:Reference entry}, Path=Text}" />
@@ -215,6 +216,10 @@
                            Text="{Binding MaxPosition}" />
                 </Grid>
 
+                <StackLayout>
+                    <Label Text="Should close on overlay tapped"/>
+                    <CheckBox x:Name="ShouldCloseOnOverlayTappedCheckbox" IsChecked="True"></CheckBox>
+                </StackLayout>
                 <Label Text="{Binding StateText, StringFormat='State: {0}'}"
                        IsVisible="{Binding StateText, Converter={dxui:IsEmptyConverter Inverted=True}}" />
                 <Button Text="Open sheet"

--- a/src/Samples/DIPS.Xamarin.UI.Samples/Controls/Sheet/SheetPage.xaml
+++ b/src/Samples/DIPS.Xamarin.UI.Samples/Controls/Sheet/SheetPage.xaml
@@ -36,7 +36,7 @@
                                     MinPosition="{Binding MinPosition}"
                                     MaxPosition="{Binding MaxPosition}"
                                     BindingContextFactory="{Binding SheetViewModelFactory}"
-                                    ShouldCloseOnOverlayTapped="{Binding Source={x:Reference ShouldCloseOnOverlayTappedCheckbox}, Path=IsChecked}"
+                                    CloseOnOverlayTapped="{Binding Source={x:Reference ShouldCloseOnOverlayTappedCheckbox}, Path=IsChecked}"
                                     OnPositionChanged="SheetBehavior_OnOnPositionChanged">
                     <StackLayout>
                         <Label Text="{Binding Source={x:Reference entry}, Path=Text}" />


### PR DESCRIPTION
## Added / Fixed

- Added properties to `Sheet`, `Popup` and `FloatingActionMenu` to turn off closing the modalities when the user taps the overlay.
- Added property to `ModalityLayout` to turn off tapping the overlay to close for all it's child modalities.

## Todo List

- [X] I have tested on an Android device.
- [X] I have tested on an iOS device.
- [ ] I have added unit tests

>*Please add pictures / Gifs if possible*
>*Todo List can be checked by putting a `X` inside the brackets*
>*Remember to update our `wiki` after this PR is merged*
