### PR TITLE
Sheet reset position to orignal position when re-opened, fixed #150

### DIFF
--- a/src/DIPS.Xamarin.UI/Controls/Sheet/SheetBehavior.cs
+++ b/src/DIPS.Xamarin.UI/Controls/Sheet/SheetBehavior.cs
@@ -119,6 +119,21 @@ namespace DIPS.Xamarin.UI.Controls.Sheet
         }
 
         /// <summary>
+        /// <see cref="ShouldRememberPosition"/>
+        /// </summary>
+        public static readonly BindableProperty ShouldRememberPositionProperty = BindableProperty.Create(nameof(ShouldRememberPosition), typeof(bool), typeof(SheetBehavior), false);
+
+        /// <summary>
+        /// Determines if the sheet should remember its position when it is opened and closed.
+        /// This is a bindable property.
+        /// </summary>
+        public bool ShouldRememberPosition
+        {
+            get => (bool)GetValue(ShouldRememberPositionProperty);
+            set => SetValue(ShouldRememberPositionProperty, value);
+        }
+
+        /// <summary>
         /// Event that gets raised when the sheet has changed it's position.
         /// </summary>
         public event EventHandler<PositionEventArgs>? OnPositionChanged;
@@ -482,6 +497,8 @@ namespace DIPS.Xamarin.UI.Controls.Sheet
         /// </summary>
         public static readonly BindableProperty CloseOnOverlayTappedProperty = BindableProperty.Create(nameof(CloseOnOverlayTapped), typeof(bool), typeof(SheetBehavior), true);
 
+        private double m_originalPosition = -1;
+
         /// <summary>
         /// <inheritdoc />
         /// </summary>
@@ -549,6 +566,18 @@ namespace DIPS.Xamarin.UI.Controls.Sheet
             if (m_modalityLayout == null)
             {
                 return;
+            }
+
+            if (!ShouldRememberPosition)
+            {
+                if (m_originalPosition == -1)
+                {
+                    m_originalPosition = Position;
+                }
+                else
+                {
+                    Position = m_originalPosition;
+                }
             }
 
             if (IsOpen)

--- a/src/DIPS.Xamarin.UI/Controls/Sheet/SheetBehavior.cs
+++ b/src/DIPS.Xamarin.UI/Controls/Sheet/SheetBehavior.cs
@@ -322,7 +322,7 @@ namespace DIPS.Xamarin.UI.Controls.Sheet
         /// </summary>
         public object OnBeforeOpenCommandParameter
         {
-            get => (object)GetValue(OnBeforeOpenCommandParameterProperty);
+            get => GetValue(OnBeforeOpenCommandParameterProperty);
             set => SetValue(OnBeforeOpenCommandParameterProperty, value);
         }
 
@@ -372,7 +372,7 @@ namespace DIPS.Xamarin.UI.Controls.Sheet
         /// </summary>
         public object OnBeforeCloseCommandParameter
         {
-            get => (object)GetValue(OnBeforeCloseCommandParameterProperty);
+            get => GetValue(OnBeforeCloseCommandParameterProperty);
             set => SetValue(OnBeforeCloseCommandParameterProperty, value);
         }
 
@@ -478,7 +478,7 @@ namespace DIPS.Xamarin.UI.Controls.Sheet
                 _ => throw new ArgumentOutOfRangeException()
             };
 
-            var translationTask = m_sheetView.SheetFrame.TranslateTo(m_sheetView.SheetFrame.X, y, 250);
+            var translationTask = m_sheetView.SheetFrame.TranslateTo(m_sheetView.SheetFrame.X, y);
             await Task.Delay(250);
             await translationTask;
         }
@@ -570,7 +570,7 @@ namespace DIPS.Xamarin.UI.Controls.Sheet
 
             if (!ShouldRememberPosition)
             {
-                if (m_originalPosition == -1)
+                if (Math.Abs(m_originalPosition - (-1)) < 0.0000001)
                 {
                     m_originalPosition = Position;
                 }
@@ -658,7 +658,7 @@ namespace DIPS.Xamarin.UI.Controls.Sheet
                 {
                     Position = MinPosition;
                 }
-                else //Auto close
+                else if(!m_fromIsOpenContext) //Auto close
                 {
                     IsOpen = false;
                 }
@@ -680,7 +680,7 @@ namespace DIPS.Xamarin.UI.Controls.Sheet
             if (m_fromIsOpenContext || !m_fromIsDraggingContext)
             {
 
-                var translationTask =  m_sheetView.SheetFrame.TranslateTo(m_sheetView.SheetFrame.X, yTranslation, 250);
+                var translationTask =  m_sheetView.SheetFrame.TranslateTo(m_sheetView.SheetFrame.X, yTranslation);
 
                 await Task.Delay(250);
                 await translationTask;

--- a/src/IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro.Android/Resources/Resource.designer.cs
+++ b/src/IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro.Android/Resources/Resource.designer.cs
@@ -15,7 +15,7 @@ namespace DIPS.Xamarin.Forms.IssuesRepro.Droid
 {
 	
 	
-	[System.CodeDom.Compiler.GeneratedCodeAttribute("Xamarin.Android.Build.Tasks", "1.0.0.0")]
+	[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Xamarin.Android.Build.Tasks", "1.0.0.0")]
 	public partial class Resource
 	{
 		

--- a/src/IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro.csproj
+++ b/src/IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro.csproj
@@ -32,6 +32,9 @@
     <EmbeddedResource Update="Github142\Github142.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
+    <EmbeddedResource Update="Github150\Github150.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
     <EmbeddedResource Update="Github64\Github64.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>

--- a/src/IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/Github150/Github150.xaml
+++ b/src/IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/Github150/Github150.xaml
@@ -1,0 +1,32 @@
+﻿<?xml version="1.0"
+      encoding="utf-8"?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:dxui="http://dips.xamarin.ui.com"
+             mc:Ignorable="d"
+             x:Class="DIPS.Xamarin.Forms.IssuesRepro.Github150.Github150"
+             Title="Github 150">
+    <dxui:ModalityLayout>
+        <dxui:ModalityLayout.Behaviors>
+            <dxui:SheetBehavior x:Name="sheetBehavior"
+                                ShouldRememberPosition="True"
+                                IsDraggable="True"
+                                Position="0.76"
+                                IsOpen="{Binding Source={x:Reference checkBox}, Path=IsChecked}">
+                <StackLayout>
+                    <Label Text="The below label should say 0.76 when it is first opened:" Padding="15"/>
+                    <Label Text="{Binding Source={x:Reference sheetBehavior}, Path=Position}" Padding="15" FontAttributes="Bold"/>
+                    <Label Text="Drag the sheet to see if the position is reset when you close and re-open it" Padding="15"/>
+                </StackLayout>
+            </dxui:SheetBehavior>
+        </dxui:ModalityLayout.Behaviors>
+        <StackLayout Orientation="Horizontal"
+                     HorizontalOptions="CenterAndExpand"
+                     VerticalOptions="CenterAndExpand">
+            <Label Text="Check to open sheet" VerticalTextAlignment="Center"/>
+            <CheckBox x:Name="checkBox" />
+        </StackLayout>
+    </dxui:ModalityLayout>
+</ContentPage>

--- a/src/IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/Github150/Github150.xaml.cs
+++ b/src/IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/Github150/Github150.xaml.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace DIPS.Xamarin.Forms.IssuesRepro.Github150
+{
+    [XamlCompilation(XamlCompilationOptions.Compile)]
+    public partial class Github150 : ContentPage
+    {
+        public Github150()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/src/IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/MainPage.xaml
+++ b/src/IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/MainPage.xaml
@@ -30,7 +30,10 @@
                 CommandParameter="137" />
         <Button Text="Github issue 142"
                 Command="{Binding NavigationCommand}"
-                CommandParameter="142" />
+                CommandParameter="142" />  
+        <Button Text="Github issue 150"
+                Command="{Binding NavigationCommand}"
+                CommandParameter="150" />
     </StackLayout>
 
 </ContentPage>

--- a/src/IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/MainViewModel.cs
+++ b/src/IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/MainViewModel.cs
@@ -26,6 +26,8 @@ namespace DIPS.Xamarin.Forms.IssuesRepro
                 Application.Current.MainPage.Navigation.PushAsync(new NewIssue.Github137());
             if (obj.Equals("142"))
                 Application.Current.MainPage.Navigation.PushAsync(new Github142.Github142());
+            if (obj.Equals("150"))
+                Application.Current.MainPage.Navigation.PushAsync(new Github150.Github150());
         }
     }
 }

--- a/src/Samples/DIPS.Xamarin.UI.Samples/Controls/Sheet/SheetPage.xaml
+++ b/src/Samples/DIPS.Xamarin.UI.Samples/Controls/Sheet/SheetPage.xaml
@@ -16,8 +16,8 @@
     </ContentPage.BindingContext>
     <Grid>
         <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
         <dxui:ModalityLayout>
             <dxui:ModalityLayout.Behaviors>
@@ -37,7 +37,7 @@
                                     MaxPosition="{Binding MaxPosition}"
                                     BindingContextFactory="{Binding SheetViewModelFactory}"
                                     CloseOnOverlayTapped="{Binding Source={x:Reference ShouldCloseOnOverlayTappedCheckbox}, Path=IsChecked}"
-                                    OnPositionChanged="SheetBehavior_OnOnPositionChanged">
+                                    ShouldRememberPosition="{Binding ShouldRememberPosition}">
                     <StackLayout>
                         <Label Text="{Binding Source={x:Reference entry}, Path=Text}" />
                         <Label Text="{Binding Source={x:Reference entry}, Path=Text}" />
@@ -142,26 +142,35 @@
                     <Grid.RowDefinitions>
                         <RowDefinition />
                         <RowDefinition />
+                        <RowDefinition />
+                        <RowDefinition />
                     </Grid.RowDefinitions>
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto" />
                         <ColumnDefinition Width="*" />
                     </Grid.ColumnDefinitions>
                     <Label Grid.Column="0"
-                           Grid.Row="0"
+                           Text="Remember position when open / close" 
+                           VerticalTextAlignment="Center"/>
+                    <CheckBox Grid.Column="1"
+                              Grid.Row="0"
+                              IsChecked="{Binding ShouldRememberPosition}" />
+                    <Label Grid.Column="0"
+                           Grid.Row="1"
                            Text="Position"
                            VerticalTextAlignment="Center" />
-                    <Slider Grid.Column="1"
-                            Grid.Row="0"
+                    <Label Grid.Column="1"
+                           Grid.Row="1"
+                           Text="{Binding Position}" />
+                    <Slider Grid.Column="0"
+                            Grid.ColumnSpan="2"
+                            IsVisible="{Binding ShouldRememberPosition}"
+                            Grid.Row="2"
                             Maximum="1"
                             Minimum="0"
                             MaximumTrackColor="Tomato"
                             MinimumTrackColor="Tomato"
                             Value="{Binding Position}" />
-                    <Label Grid.Column="0"
-                           Grid.ColumnSpan="2"
-                           Grid.Row="1"
-                           Text="{Binding Position}" />
                 </Grid>
 
                 <Grid>
@@ -217,8 +226,9 @@
                 </Grid>
 
                 <StackLayout>
-                    <Label Text="Should close on overlay tapped"/>
-                    <CheckBox x:Name="ShouldCloseOnOverlayTappedCheckbox" IsChecked="True"></CheckBox>
+                    <Label Text="Should close on overlay tapped" />
+                    <CheckBox x:Name="ShouldCloseOnOverlayTappedCheckbox"
+                              IsChecked="True" />
                 </StackLayout>
                 <Label Text="{Binding StateText, StringFormat='State: {0}'}"
                        IsVisible="{Binding StateText, Converter={dxui:IsEmptyConverter Inverted=True}}" />

--- a/src/Samples/DIPS.Xamarin.UI.Samples/Controls/Sheet/SheetPage.xaml.cs
+++ b/src/Samples/DIPS.Xamarin.UI.Samples/Controls/Sheet/SheetPage.xaml.cs
@@ -19,7 +19,8 @@ namespace DIPS.Xamarin.UI.Samples.Controls.Sheet
 
         private void SheetBehavior_OnOnPositionChanged(object sender, EventArgs e)
         {
-            
+            if (!(sender is SheetBehavior sheetBehavior)) return;
+            sheetBehavior.Position = 0.9;
         }
     }
 
@@ -36,6 +37,7 @@ namespace DIPS.Xamarin.UI.Samples.Controls.Sheet
         private double m_maxPosition = 1;
         private double m_minPosition = 0.05;
         private string m_stateText;
+        private bool m_shouldRememberPosition;
 
         public SheetPageViewModel()
         {
@@ -154,6 +156,12 @@ namespace DIPS.Xamarin.UI.Samples.Controls.Sheet
         {
             get => m_stateText;
             set => PropertyChanged.RaiseWhenSet(ref m_stateText, value);
+        }
+
+        public bool ShouldRememberPosition
+        {
+            get => m_shouldRememberPosition;
+            set => PropertyChanged.RaiseWhenSet(ref m_shouldRememberPosition, value);
         }
 
         public event PropertyChangedEventHandler PropertyChanged;


### PR DESCRIPTION
## Added / Fixed
Sheet 
    - Added a original position member field to keep the original position
    - Added a new property to make sure the sheet remembers position

## Todo List

- [X] I have tested on an Android device.
- [X] I have tested on an iOS device.
- [ ] I have added unit tests

>*Please add pictures / Gifs if possible*
>*Todo List can be checked by putting a `X` inside the brackets*
>*Remember to update our `wiki` after this PR is merged*
