### PR TITLE
Added Inspector, a API to inspect the native control of a shared control.

### DIFF
--- a/src/DIPS.Xamarin.UI.Android/DIPS.Xamarin.UI.Android.csproj
+++ b/src/DIPS.Xamarin.UI.Android/DIPS.Xamarin.UI.Android.csproj
@@ -47,6 +47,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Util\Inspector.cs" />
     <Compile Include="LegacyButtonRenderer.cs" />
     <Compile Include="Library.cs" />
     <Compile Include="Resources\Resource.designer.cs" />

--- a/src/DIPS.Xamarin.UI.Android/Library.cs
+++ b/src/DIPS.Xamarin.UI.Android/Library.cs
@@ -1,4 +1,5 @@
 ﻿using Android.Graphics.Pdf;
+using DIPS.Xamarin.UI.Internal.Utilities;
 
 namespace DIPS.Xamarin.UI.Android
 {
@@ -13,6 +14,7 @@ namespace DIPS.Xamarin.UI.Android
         /// </summary>
         public static void Initialize()
         {
+            Inspector.Instance = new Util.Inspector();
         }
     }
 }

--- a/src/DIPS.Xamarin.UI.Android/Util/Inspector.cs
+++ b/src/DIPS.Xamarin.UI.Android/Util/Inspector.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using DIPS.Xamarin.UI.Internal.Utilities;
+using Xamarin.Forms;
+using Xamarin.Forms.Platform.Android;
+
+namespace DIPS.Xamarin.UI.Android.Util
+{
+    /// <summary>
+    /// Used to set callbacks to inspect the native implementation of a shared view-class. <see href="https://github.com/DIPSAS/DIPS.Xamarin.UI/wiki/Inspector">(wiki doc)</see>
+    /// <example><see cref="OnInspectingViewCallback"/> sends the native implementation of <see cref="global::Android.Views.View"/> when a <see cref="View"/> is getting inspected></example>
+    /// </summary>
+    public class Inspector : IInspector
+    {
+        /// <summary>
+        /// A callback that should be invoked when the inspector has collected a <see cref="global::Android.Views.View"/> from a <see cref="View"/>
+        /// </summary>
+        public static Action<global::Android.Views.View> OnInspectingViewCallback { get; set; }
+
+        void IInspector.Inspect(View view)
+        {
+            var renderer = Platform.GetRenderer(view);
+            Platform.SetRenderer(view, renderer);
+            var nativeView = renderer?.View;
+            OnInspectingViewCallback?.Invoke(nativeView);
+        }
+    }
+}

--- a/src/DIPS.Xamarin.UI.iOS/DIPS.Xamarin.UI.iOS.csproj
+++ b/src/DIPS.Xamarin.UI.iOS/DIPS.Xamarin.UI.iOS.csproj
@@ -42,6 +42,7 @@
     <Folder Include="Resources\" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Util\Inspector.cs" />
     <Compile Include="Library.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/src/DIPS.Xamarin.UI.iOS/Library.cs
+++ b/src/DIPS.Xamarin.UI.iOS/Library.cs
@@ -1,4 +1,5 @@
-﻿using Foundation;
+﻿using DIPS.Xamarin.UI.iOS.Util;
+using Foundation;
 using UIKit;
 
 namespace DIPS.Xamarin.UI.iOS
@@ -13,6 +14,7 @@ namespace DIPS.Xamarin.UI.iOS
         /// </summary>
         public static void Initialize()
         {
+            DIPS.Xamarin.UI.Internal.Utilities.Inspector.Instance = new Inspector();
         }
     }
 }

--- a/src/DIPS.Xamarin.UI.iOS/Util/Inspector.cs
+++ b/src/DIPS.Xamarin.UI.iOS/Util/Inspector.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using DIPS.Xamarin.UI.Internal.Utilities;
+using UIKit;
+using Xamarin.Forms;
+using Xamarin.Forms.Platform.iOS;
+
+namespace DIPS.Xamarin.UI.iOS.Util
+{
+    /// <summary>
+    /// Used to set callbacks to inspect the native implementation of a shared view-class. <see href="https://github.com/DIPSAS/DIPS.Xamarin.UI/wiki/Inspector">(wiki doc)</see>
+    /// <example><see cref="OnInspectingViewCallback"/> sends the native implementation of <see cref="UIView"/> when a <see cref="View"/> is getting inspected</example>
+    /// </summary>
+    public class Inspector : IInspector
+    {
+        /// <summary>
+        /// A callback that should be invoked when the inspector has collected a <see cref="UIView"/> from a <see cref="View"/>
+        /// </summary>
+        public static Action<UIView> OnInspectingViewCallback { get; set; }
+
+        void IInspector.Inspect(View view)
+        {
+            var renderer = Platform.CreateRenderer(view);
+            var nativeView = renderer?.NativeView;
+            OnInspectingViewCallback?.Invoke(nativeView);
+        }
+    }
+}

--- a/src/DIPS.Xamarin.UI/AssemblyInfo.cs
+++ b/src/DIPS.Xamarin.UI/AssemblyInfo.cs
@@ -6,6 +6,8 @@ using Xamarin.Forms.Xaml;
 [assembly: XamlCompilation(XamlCompilationOptions.Compile)]
 [assembly: Preserve]
 [assembly:InternalsVisibleTo("DIPS.Xamarin.UI.Tests")]
+[assembly: InternalsVisibleTo("DIPS.Xamarin.UI.Android")]
+[assembly: InternalsVisibleTo("DIPS.Xamarin.UI.iOS")]
 
 //Add new namespaces below to make them visible when using Custom Namespace : https://github.com/DIPSAS/DIPS.Xamarin.UI/issues/1
 [assembly:XmlnsPrefix("http://dips.xamarin.ui.com", "dxui")]

--- a/src/DIPS.Xamarin.UI/Extensions/ViewExtensions.cs
+++ b/src/DIPS.Xamarin.UI/Extensions/ViewExtensions.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using DIPS.Xamarin.UI.Internal.Utilities;
+using Xamarin.Forms;
+
+namespace DIPS.Xamarin.UI.Extensions
+{
+    /// <summary>
+    /// An extensions class for <see cref="View"/>
+    /// </summary>
+    public static class ViewExtensions
+    {
+        /// <summary>
+        /// Will send the native implementation of the <see cref="View"/> to a callback method that you need to define in each platform.
+        /// This makes it possible to inspect the native view at run time. <see href="https://github.com/DIPSAS/DIPS.Xamarin.UI/wiki/Inspector">(wiki doc)</see>
+        /// </summary>
+        /// <remarks>This can not be called unless <see cref="Library.Initialize"/> has been called on the platform</remarks>
+        /// <param name="view">The <see cref="View"/> to inspect</param>
+        public static void Inspect(this View view)
+        {
+            if (Inspector.Instance == null)
+            {
+                throw new Exception($"Library.Initialize needs to be called in the platform before inspecting. Please read the getting started: https://github.com/DIPSAS/DIPS.Xamarin.UI/wiki/Getting-Started#initializing");
+            }
+            Inspector.Instance.Inspect(view);
+        }
+    }
+}

--- a/src/DIPS.Xamarin.UI/Extensions/ViewExtensions.cs
+++ b/src/DIPS.Xamarin.UI/Extensions/ViewExtensions.cs
@@ -19,7 +19,7 @@ namespace DIPS.Xamarin.UI.Extensions
         {
             if (Inspector.Instance == null)
             {
-                throw new Exception($"Library.Initialize needs to be called in the platform before inspecting. Please read the getting started: https://github.com/DIPSAS/DIPS.Xamarin.UI/wiki/Getting-Started#initializing");
+                throw new Exception($"Library.Initialize needs to be called in the platform before inspecting. Please read the getting started: https://github.com/DIPSAS/DIPS.Xamarin.UI/wiki/Inspector#getting-started");
             }
             Inspector.Instance.Inspect(view);
         }

--- a/src/DIPS.Xamarin.UI/Internal/Utilities/Inspector.cs
+++ b/src/DIPS.Xamarin.UI/Internal/Utilities/Inspector.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using Xamarin.Forms;
+
+namespace DIPS.Xamarin.UI.Internal.Utilities
+{
+    internal class Inspector
+    {
+        internal static IInspector? Instance { get; set; }
+    }
+
+    internal interface IInspector
+    {
+        void Inspect(View view);
+    }
+}


### PR DESCRIPTION
## Added / Fixed

- Documentation is written [here](https://github.com/DIPSAS/DIPS.Xamarin.UI/wiki/Inspector) and pasted below.

## Todo List

- [X] I have tested on an Android device.
- [X] I have tested on an iOS device.
- [ ] I have added unit tests

The below documentation is from our [wiki](https://github.com/DIPSAS/DIPS.Xamarin.UI/wiki/Inspector)
----

# Introduction
When working with `Xamarin.Forms` we have the pleasure of having shared UI code to create our human interfaces for both Android and iOS. You will spend most of your time in this shared code.

There are cases where you will have to dive down to the platforms in order to customize the appearance or maybe subscribe to / delegate events for different controls. `Xamarin.Forms` gives us the possibilities of using [Custom Renderers](https://docs.microsoft.com/en-us/xamarin/xamarin-forms/app-fundamentals/custom-renderer/) or [Effects](https://docs.microsoft.com/en-us/xamarin/xamarin-forms/app-fundamentals/effects/introduction) to do so. This is a really nice way of extending the XAML language with platform specific behavior.

# The problem

When creating apps you might find yourself wondering what is going on down in the platform. Or you might just want to take a look at the native control and see what possibilities you have.
Creating a [Custom Renderers](https://docs.microsoft.com/en-us/xamarin/xamarin-forms/app-fundamentals/custom-renderer/) or [Effects](https://docs.microsoft.com/en-us/xamarin/xamarin-forms/app-fundamentals/effects/introduction) in those situations can be time consuming. After all, you just want to inspect a native control and get to know it before deciding what to do.

# The solution

We have provided an extension based way to inspect the native control that is being used for the shared control you are using. The only requirements are that you tell your control to `.Inspect()` and a callback that provides the native control will get invoked in the platform.

# Getting started
1. Make sure you have [initialized](https://github.com/DIPSAS/DIPS.Xamarin.UI/wiki/Getting-Started#initializing) the library.

2. Go to the code-behind of your XAML and add the following to whatever place you find fitting:

```csharp

protected override void OnAppearing()
{
    ...
    MyCheckBox.Inspect();
}
```
> In this example we are doing it in the `OnAppearing` and we have a `CheckBox` that has a `x:Name=MyCheckBox` in our XAML.

3. Add the following in the appropriate platform:

```csharp
public void FinishedLaunching(...)
{
     ...
     Inspector.OnInspectingViewCallback = OnInspectingViewCallback;
     ...
}

private void OnInspectingViewCallback(UIView uiView)
{
            
}

```
> In this example we are setting the callback in iOS `FinishedLaunching` and as we did the inspection for a `View` in the shared code, we get a `OnInspectingViewCallback`.

Voila! :star: You can now set a breakpoint in the callback and inspect the native control that has been used for your `View`.

# Careful

Do not get tempted to use the inspector as a way to modify your controls. This is a static based API and you will find yourself having to handle all of the possible problems that might occur when you have multiple inspections going on in a app.

You should stick to using [Custom Renderers](https://docs.microsoft.com/en-us/xamarin/xamarin-forms/app-fundamentals/custom-renderer/) or [Effects](https://docs.microsoft.com/en-us/xamarin/xamarin-forms/app-fundamentals/effects/introduction) to create the best possible API out of your modifications. Afterall, we do love XAML!

# Supported inspections
| Shared | iOS | Android |
|--------|----|---------|
| [View](https://docs.microsoft.com/en-us/dotnet/api/xamarin.forms.view?view=xamarin-forms) | [UIView](https://developer.apple.com/documentation/uikit/uiview) | [View](https://developer.android.com/reference/android/view/View)|