### PR TITLE
Removed shadow on modalitylatout overlay

### DIFF
--- a/src/DIPS.Xamarin.UI/Controls/Modality/ModalityLayout.xaml.cs
+++ b/src/DIPS.Xamarin.UI/Controls/Modality/ModalityLayout.xaml.cs
@@ -135,7 +135,7 @@ namespace DIPS.Xamarin.UI.Controls.Modality
 
         private Frame CreateOverlay()
         {
-            var overlayFrame = new Frame { BackgroundColor = OverlayColor, IsVisible = true, Opacity = 0.0 };
+            var overlayFrame = new Frame { BackgroundColor = OverlayColor, IsVisible = true, Opacity = 0.0, HasShadow = false};
             var tappedCommand = new Command(
                 () => m_closeModalityRecognizer.Command.Execute(null),
                 () => CurrentShowingModalityLayout != null && CurrentShowingModalityLayout.CloseOnOverlayTapped &&

--- a/src/Samples/DIPS.Xamarin.UI.Samples/Controls/Popup/PopupPage.xaml
+++ b/src/Samples/DIPS.Xamarin.UI.Samples/Controls/Popup/PopupPage.xaml
@@ -21,7 +21,7 @@
         </Style>
 
         <DataTemplate x:Key="dt1">
-            <Frame BackgroundColor="DarkGreen" CornerRadius="0">
+            <Frame HasShadow="False" BackgroundColor="DarkGreen" CornerRadius="0">
                 <StackLayout>
                     <CheckBox IsChecked="{Binding IsOpen}" />
 
@@ -39,7 +39,7 @@
             </Frame>
         </DataTemplate>
         <DataTemplate x:Key="dt2">
-            <Frame BackgroundColor="DarkBlue" CornerRadius="0">
+            <Frame HasShadow="False" BackgroundColor="DarkBlue" CornerRadius="0">
                 <StackLayout>
                     <CheckBox IsChecked="{Binding IsOpen}" />
 
@@ -57,7 +57,7 @@
             </Frame>
         </DataTemplate>
     </ContentPage.Resources>
-    <dxui:ModalityLayout CloseModalitiesOnOverlayTapped="False">
+    <dxui:ModalityLayout>
         <Grid BackgroundColor="WhiteSmoke">
             <Grid>
                 <Grid.RowDefinitions>
@@ -78,7 +78,7 @@
                         BindingContextFactory="{Binding GetViewModel}"
                         HorizontalOptions="RightAlign"
                         VerticalOptions="Below">
-                        <Frame Margin="10" Style="{StaticResource popupContentStyle}">
+                        <Frame HasShadow="False" Margin="10" Style="{StaticResource popupContentStyle}">
                             <Label Margin="20" Text="{Binding MyString}" />
                         </Frame>
                     </dxui:PopupBehavior>
@@ -96,7 +96,7 @@
                         BindingContextFactory="{Binding FilterViewModelFactory}"
                         HorizontalOptions="Left"
                         VerticalOptions="Center">
-                        <Frame Margin="1" Style="{StaticResource popupContentStyle}">
+                        <Frame HasShadow="False" Margin="1" Style="{StaticResource popupContentStyle}">
                             <StackLayout Orientation="Vertical">
                                 <Label Margin="5" Text="This is a long header to prove the automatic X placement" />
                                 <CheckBox


### PR DESCRIPTION
## Background
When bumping Xamarin.Forms to the latest version in my private project I noticed that the overlay of ModalityLayout did not fade down anymore on iOS. I think this is related to https://github.com/xamarin/Xamarin.Forms/issues/10024. 


## Added / Fixed

- Removed Frame Shadow on ModalityLayout overlay.
- Removed shadow from popup page samples

## Todo List

- [X] I have tested on an Android device.
- [X] I have tested on an iOS device.
- [ ] I have added unit tests
