### PR TITLE
SlidableLayout can now update from ViewModel before being used.

### DIFF
--- a/src/DIPS.Xamarin.UI/Controls/Slidable/DefaultSliderView.cs
+++ b/src/DIPS.Xamarin.UI/Controls/Slidable/DefaultSliderView.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using DIPS.Xamarin.UI.Resources.Colors;
 using Xamarin.Forms;
 namespace DIPS.Xamarin.UI.Controls.Slidable
 {
@@ -8,7 +9,7 @@ namespace DIPS.Xamarin.UI.Controls.Slidable
         {
             Margin = 0;
             WidthRequest = 3;
-            Color = Color.DarkGreen;
+            Color = Theme.TealPrimary;
             CornerRadius = 1;
             HorizontalOptions = LayoutOptions.Center;
             VerticalOptions = LayoutOptions.Center;

--- a/src/DIPS.Xamarin.UI/Controls/Slidable/SlidableLayout.cs
+++ b/src/DIPS.Xamarin.UI/Controls/Slidable/SlidableLayout.cs
@@ -15,7 +15,7 @@ namespace DIPS.Xamarin.UI.Controls.Slidable
     {
         private readonly PanGestureRecognizer m_rec = new PanGestureRecognizer();
         private readonly AccelerationService m_accelerator = new AccelerationService(true);
-        private int m_lastId = -1;
+        private int m_lastId = -2; // Different than default of SlideProperties
         private double m_startSlideLocation;
         private int m_lastIndex = int.MinValue;
         private bool disableTouchScroll;
@@ -245,7 +245,7 @@ namespace DIPS.Xamarin.UI.Controls.Slidable
             typeof(SlidableProperties),
             typeof(SlidableLayout),
             defaultBindingMode: BindingMode.TwoWay,
-            defaultValue: new SlidableProperties(0, -1, false),
+            defaultValue: new SlidableProperties(0),
             propertyChanged: OnChanged);
 
         /// <summary>

--- a/src/DIPS.Xamarin.UI/Controls/Slidable/SlidableProperties.cs
+++ b/src/DIPS.Xamarin.UI/Controls/Slidable/SlidableProperties.cs
@@ -10,7 +10,6 @@
             Position = position;
             HoldId = holdId;
             IsHeld = isHeld;
-            //tests
         }
 
         /// <summary>

--- a/src/Samples/DIPS.Xamarin.UI.Samples/Controls/SlideLayout/SlideLayoutPage.xaml
+++ b/src/Samples/DIPS.Xamarin.UI.Samples/Controls/SlideLayout/SlideLayoutPage.xaml
@@ -24,6 +24,7 @@
             x:Name="layout"
             Grid.Row="4"
             Padding="0,10"
+            SlideProperties="{Binding SlidableProperties}"
             BindingContextFactory="{Binding CreateCalendar}"
             SelectedItemChangedCommand="{Binding OnSelectedIndexChangedCommand}">
             <dxui:SlidableContentLayout.Config>
@@ -67,7 +68,7 @@
             BindingContextFactory="{Binding CreateCalendar}"
             ScaleDown="True"
             SelectedItemChangedCommand="{Binding OnSelectedIndexChangedCommand}"
-            SlideProperties="{Binding Source={x:Reference layout}, Path=SlideProperties}">
+            SlideProperties="{Binding SlidableProperties}">
             <dxui:SlidableContentLayout.Config>
                 <dxui:SliderConfig MaxValue="5" MinValue="-5" />
             </dxui:SlidableContentLayout.Config>
@@ -110,7 +111,7 @@
             BindingContextFactory="{Binding CreateCalendar}"
             ScaleDown="False"
             SelectedItemChangedCommand="{Binding OnSelectedIndexChangedCommand}"
-            SlideProperties="{Binding Source={x:Reference layout}, Path=SlideProperties}"
+            SlideProperties="{Binding SlidableProperties}"
             VibrateOnSelectionChanged="True">
             <dxui:SlidableContentLayout.Config>
                 <dxui:SliderConfig MaxValue="5" MinValue="-20" />

--- a/src/Samples/DIPS.Xamarin.UI.Samples/Controls/SlideLayout/SlideLayoutPage.xaml.cs
+++ b/src/Samples/DIPS.Xamarin.UI.Samples/Controls/SlideLayout/SlideLayoutPage.xaml.cs
@@ -9,9 +9,8 @@ namespace DIPS.Xamarin.UI.Samples.Controls.SlideLayout
     {
         public SlideLayoutPage()
         {
-            BindingContext = new SlideLayoutViewModel();
-
             InitializeComponent();
+            BindingContext = new SlideLayoutViewModel();
         }
 
         protected override void OnAppearing()

--- a/src/Samples/DIPS.Xamarin.UI.Samples/Controls/SlideLayout/SlideLayoutViewModel.cs
+++ b/src/Samples/DIPS.Xamarin.UI.Samples/Controls/SlideLayout/SlideLayoutViewModel.cs
@@ -17,11 +17,15 @@ namespace DIPS.Xamarin.UI.Samples.Controls.SlideLayout
         public SlideLayoutViewModel()
         {
             OnSelectedIndexChangedCommand = new Command(o => Selected = o.ToString());
+            
         }
 
-        public void Initialize()
+        public async void Initialize()
         {
-            SlidableProperties = new SlidableProperties(4);
+            await Task.Delay(1);
+            SlidableProperties = new SlidableProperties(1);
+            await Task.Delay(1000);
+            SlidableProperties = new SlidableProperties(-3);
         }
 
         public SliderConfig Config => new SliderConfig(-10, 0);


### PR DESCRIPTION
## Added / Fixed

- SlidableLayout has a different initial hold id set. To not override values set from the ViewModel

## Todo List

- [X] I have tested on an Android device.
- [X] I have tested on an iOS device.
