### PR TITLE
Floating button keeps X position on rotation

### DIFF
--- a/src/DIPS.Xamarin.UI/Internal/Xaml/FloatingActionMenu.xaml.cs
+++ b/src/DIPS.Xamarin.UI/Internal/Xaml/FloatingActionMenu.xaml.cs
@@ -189,7 +189,7 @@ namespace DIPS.Xamarin.UI.Internal.Xaml
 
             foreach (var child in Children)
             {
-                RelativeLayout.SetXConstraint(child, Constraint.RelativeToParent(p => (p.Width * m_behaviour.XPosition) - ExpandButton.WidthRequest + m_behaviour.Size - child.Width));
+                RelativeLayout.SetXConstraint(child, Constraint.RelativeToParent(p => ExpandButton.X + m_behaviour.Size - child.Width));
             }
 
             m_first = false;

--- a/src/DIPS.Xamarin.UI/Internal/Xaml/FloatingActionMenu.xaml.cs
+++ b/src/DIPS.Xamarin.UI/Internal/Xaml/FloatingActionMenu.xaml.cs
@@ -189,7 +189,7 @@ namespace DIPS.Xamarin.UI.Internal.Xaml
 
             foreach (var child in Children)
             {
-                RelativeLayout.SetXConstraint(child, Constraint.Constant(ExpandButton.X + m_behaviour.Size - child.Width));
+                RelativeLayout.SetXConstraint(child, Constraint.RelativeToParent(p => (p.Width * m_behaviour.XPosition) - ExpandButton.WidthRequest + m_behaviour.Size - child.Width));
             }
 
             m_first = false;


### PR DESCRIPTION
#172

## Added / Fixed

Floating button keeps correct position when you rotate the device

## Todo List

- [X] I have tested on an Android device.
- [X] I have tested on an iOS device.

<img width="874" alt="Skjermbilde 2020-05-28 kl  09 46 48" src="https://user-images.githubusercontent.com/1519936/83114249-07ec0380-a0c9-11ea-9055-edad27f0313a.png">
<img width="412" alt="Skjermbilde 2020-05-28 kl  09 46 59" src="https://user-images.githubusercontent.com/1519936/83114255-0a4e5d80-a0c9-11ea-9b3a-163302ec12b9.png">
