### PR TITLE
Menubutton visibility toggle

### DIFF
--- a/src/DIPS.Xamarin.UI/Controls/FloatingActionMenu/MenuButton.xaml.cs
+++ b/src/DIPS.Xamarin.UI/Controls/FloatingActionMenu/MenuButton.xaml.cs
@@ -326,6 +326,9 @@ namespace DIPS.Xamarin.UI.Controls.FloatingActionMenu
             set => SetValue(TitleProperty, value);
         }
 
+        /// <summary>
+        /// <see cref="IsVisible"/>
+        /// </summary>
         public new static readonly BindableProperty IsVisibleProperty = BindableProperty.Create(nameof(IsVisible), typeof(bool), typeof(MenuButton), propertyChanged:OnIsVisibleChanged, defaultBindingMode: BindingMode.TwoWay);
 
         private static void OnIsVisibleChanged(BindableObject bindable, object oldvalue, object newvalue)
@@ -336,6 +339,10 @@ namespace DIPS.Xamarin.UI.Controls.FloatingActionMenu
             }
         }
 
+        /// <summary>
+        ///     Gets or sets a value that determines whether this elements should be part of the visual tree or not.
+        ///     This is a bindable property.
+        /// </summary>
         public new bool IsVisible
         {
             get => (bool)GetValue(IsVisibleProperty);

--- a/src/DIPS.Xamarin.UI/Controls/FloatingActionMenu/MenuButton.xaml.cs
+++ b/src/DIPS.Xamarin.UI/Controls/FloatingActionMenu/MenuButton.xaml.cs
@@ -326,10 +326,26 @@ namespace DIPS.Xamarin.UI.Controls.FloatingActionMenu
             set => SetValue(TitleProperty, value);
         }
 
+        public new static readonly BindableProperty IsVisibleProperty = BindableProperty.Create(nameof(IsVisible), typeof(bool), typeof(MenuButton), propertyChanged:OnIsVisibleChanged, defaultBindingMode: BindingMode.TwoWay);
+
+        private static void OnIsVisibleChanged(BindableObject bindable, object oldvalue, object newvalue)
+        {
+            if (bindable is MenuButton menuButton)
+            {
+                menuButton.FloatingActionMenuParent?.UpdateMenuButtonVisibility(menuButton, (bool)newvalue);
+            }
+        }
+
+        public new bool IsVisible
+        {
+            get => (bool)GetValue(IsVisibleProperty);
+            set => SetValue(IsVisibleProperty, value);
+        }
+
         private static async void IsBadgeVisiblePropertyChanged(BindableObject bindable, object oldvalue,
             object newvalue)
         {
-            if (!Library.PreviewFeatures.MenuButtonBadgeAnimation)
+            if (!Library.PreviewFeatures.MenuButtonAnimations)
             {
                 return;
             }
@@ -380,7 +396,7 @@ namespace DIPS.Xamarin.UI.Controls.FloatingActionMenu
                 return;
             }
 
-            if (!Library.PreviewFeatures.MenuButtonBadgeAnimation)
+            if (!Library.PreviewFeatures.MenuButtonAnimations)
             {
                 return;
             }

--- a/src/DIPS.Xamarin.UI/Library.cs
+++ b/src/DIPS.Xamarin.UI/Library.cs
@@ -27,14 +27,14 @@ namespace DIPS.Xamarin.UI
             /// <param name="previewFeature">A string specifying which preview feature you want to enable.</param>
             public static void EnableFeature(string previewFeature)
             {
-                if (previewFeature == "MenuButtonBadgeAnimation") MenuButtonBadgeAnimation = true;
+                if (previewFeature == "MenuButtonBadgeAnimation") MenuButtonAnimations = true;
                 if (previewFeature == "SkeletonView") SkeletonView = true;
             }
 
             /// <summary>
             ///     Toggles animations for the badge on the <see cref="MenuButton"/>
             /// </summary>
-            public static bool MenuButtonBadgeAnimation { get; set; }
+            public static bool MenuButtonAnimations { get; set; }
 
             /// <summary>
             /// Toggles usage of SkeletonView <see cref="SkeletonView"/>

--- a/src/Samples/DIPS.Xamarin.UI.Samples/Controls/FloatingActionMenu/FloatingActionMenuPage.xaml
+++ b/src/Samples/DIPS.Xamarin.UI.Samples/Controls/FloatingActionMenu/FloatingActionMenuPage.xaml
@@ -1,4 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0"
+      encoding="utf-8"?>
 
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
@@ -47,33 +48,36 @@
                                               YPosition=".95"
                                               CloseOnOverlayTapped="{Binding Source={x:Reference shouldCloseOnTappedOverlayCheckbox}, Path=IsChecked}"
                                               IsVisible="{Binding Source={x:Reference toggleVisibilityCheckbox}, Path=IsChecked}">
-                <dxui:MenuButton BackgroundColor="LightSeaGreen"
-                                 Text="Home"
-                                 x:Name="FirstButton"
-                                 TextColor="White"
-                                 Command="{Binding SetTextCommand}"
-                                 Title="First page"
-                                 CommandParameter="First tapped!" />
+
+
                 <dxui:MenuButton BackgroundColor="LightSeaGreen"
                                  Text="A"
+                                 x:Name="FirstButton"
                                  TextColor="White"
-                                 Title="Second page"
+                                 Command="{Binding ToggleButtonVisibilityCommand}"
+                                 Title="Toggle C visibility"
+                                 CommandParameter="First tapped!" />
+                <dxui:MenuButton BackgroundColor="LightSeaGreen"
+                                 Text="B"
+                                 TextColor="White"
+                                 Title="First page"
                                  Command="{Binding SetTextCommand}"
                                  CommandParameter="Second tapped!" />
                 <dxui:MenuButton BackgroundColor="LightSeaGreen"
-                                 Text="B"
+                                 Text="C"
                                  TextColor="White"
                                  IsBadgeVisible="{Binding ShowBadge}"
                                  BadgeColor="{Binding BadgeColor}"
                                  BadgeCount="{Binding BadgeCounter}"
-                                 Title="Third page"
-                                 IsEnabled="False"
+                                 IsVisible="{Binding IsMenuButtonVisible}"
+                                 Title="Second page"
                                  Command="{Binding SetTextCommand}"
+                                 IsEnabled="False"
                                  CommandParameter="Third tapped!" />
                 <dxui:MenuButton BackgroundColor="LightSeaGreen"
-                                 Text="C"
+                                 Text="D"
                                  TextColor="White"
-                                 Title="Fourth page"
+                                 Title="Third page"
                                  Command="{Binding SetTextCommand}"
                                  CommandParameter="Fourth tapped!" />
             </dxui:FloatingActionMenuBehaviour>
@@ -102,7 +106,7 @@
                 </StackLayout>
 
                 <StackLayout Orientation="Horizontal">
-                    <Label Text="Enable badge animations"
+                    <Label Text="Enable menu button animations"
                            VerticalTextAlignment="Center" />
                     <CheckBox CheckedChanged="CheckBox_OnCheckedChanged" />
                 </StackLayout>

--- a/src/Samples/DIPS.Xamarin.UI.Samples/Controls/FloatingActionMenu/FloatingActionMenuPage.xaml.cs
+++ b/src/Samples/DIPS.Xamarin.UI.Samples/Controls/FloatingActionMenu/FloatingActionMenuPage.xaml.cs
@@ -23,7 +23,7 @@ namespace DIPS.Xamarin.UI.Samples.Controls.FloatingActionMenu
 
         private void CheckBox_OnCheckedChanged(object sender, CheckedChangedEventArgs e)
         {
-            Library.PreviewFeatures.MenuButtonBadgeAnimation = e.Value;
+            Library.PreviewFeatures.MenuButtonAnimations = e.Value;
         }
 
         private void FloatingActionMenuBehaviour_OnAfterClose(object sender, EventArgs e)
@@ -55,6 +55,7 @@ namespace DIPS.Xamarin.UI.Samples.Controls.FloatingActionMenu
         private int m_badgeCounter;
         private Color m_badgeColor;
         private string m_currentEvent;
+        private bool m_isMenuButtonVisible = true;
 
         public FloatingActionMenuPageViewmodel()
         {
@@ -67,6 +68,7 @@ namespace DIPS.Xamarin.UI.Samples.Controls.FloatingActionMenu
                 if ( BadgeColor != Color.BlueViolet) BadgeColor = Color.BlueViolet;
                 else BadgeColor = Color.IndianRed;
             });
+            ToggleButtonVisibilityCommand = new Command(() => IsMenuButtonVisible = !IsMenuButtonVisible);
 
         }
 
@@ -76,6 +78,7 @@ namespace DIPS.Xamarin.UI.Samples.Controls.FloatingActionMenu
         public ICommand ChangeBadgeColorCommand { get; set; }
         public ICommand IncreaseCounterCommand { get; set; }
         public ICommand DecreaseCounterCommand { get; set; }
+        public ICommand ToggleButtonVisibilityCommand { get; set; }
 
         public Color BadgeColor
         {
@@ -107,5 +110,10 @@ namespace DIPS.Xamarin.UI.Samples.Controls.FloatingActionMenu
             set => PropertyChanged.RaiseWhenSet(ref m_currentEvent, value);
         }
 
+        public bool IsMenuButtonVisible
+        {
+            get => m_isMenuButtonVisible;
+            set => PropertyChanged.RaiseWhenSet(ref m_isMenuButtonVisible, value);
+        }
     }
 }


### PR DESCRIPTION
Removes menubutton properly when toggling visibility when menu is expanded.

## Added / Fixed

- Fixed #187 

## Todo List

- [x] I have tested on an Android device.
- [x] I have tested on an iOS device.
- [ ] I have added unit tests

>*Please add pictures / Gifs if possible*
>*Todo List can be checked by putting a `X` inside the brackets*
>*Remember to update our `wiki` after this PR is merged*
