### PR TITLE
Time/DatePicker can now set their background color

### DIFF
--- a/src/DIPS.Xamarin.UI/Controls/DatePicker/DatePicker.xaml
+++ b/src/DIPS.Xamarin.UI/Controls/DatePicker/DatePicker.xaml
@@ -13,12 +13,14 @@
                     Date="{Binding Source={x:Reference codeBehind}, Path=Date}"
                     MaximumDate="{Binding Source={x:Reference codeBehind}, Path=MaximumDate}"
                     MinimumDate="{Binding Source={x:Reference codeBehind}, Path=MinimumDate}"
+                    BackgroundColor="{Binding Source={x:Reference codeBehind}, Path=BackgroundColor}"
                     Margin="{Binding Source={x:Reference DateLabel}, Path=Height, Converter={ValueConverters:MultiplicationConverter Factor=-1}}"
                     TextColor="Transparent"
                     HeightRequest="{Binding Source={x:Reference DateLabel}, Path=Height}"
                     WidthRequest="{Binding Source={x:Reference DateLabel}, Path=Width}" />
         <Label x:Name="DateLabel"
                TextColor="{Binding Source={x:Reference codeBehind}, Path=LabelColor}"
+               BackgroundColor="{Binding Source={x:Reference codeBehind}, Path=BackgroundColor}"
                InputTransparent="True"
                HorizontalOptions="{Binding Source={x:Reference codeBehind}, Path=HorizontalOptions}"
                VerticalOptions="{Binding Source={x:Reference codeBehind}, Path=VerticalOptions}" />

--- a/src/DIPS.Xamarin.UI/Controls/TimePicker/TimePicker.xaml
+++ b/src/DIPS.Xamarin.UI/Controls/TimePicker/TimePicker.xaml
@@ -12,6 +12,7 @@
         <TimePicker x:Name="FormsTimePicker"
                     Time="{Binding Source={x:Reference codeBehind}, Path=Time}"
                     Margin="{Binding Source={x:Reference TimeLabel}, Path=Height, Converter={ValueConverters:MultiplicationConverter Factor=-1}}"
+                    BackgroundColor="{Binding Source={x:Reference codeBehind}, Path=BackgroundColor}"
                     TextColor="Transparent"
                     HeightRequest="{Binding Source={x:Reference TimeLabel}, Path=Height}"
                     WidthRequest="{Binding Source={x:Reference TimeLabel}, Path=Width}" />
@@ -19,6 +20,7 @@
                Text="{Binding Source={x:Reference codeBehind}, Path=Time}"
                TextColor="{Binding Source={x:Reference codeBehind}, Path=LabelColor}"
                InputTransparent="True"
+               BackgroundColor="{Binding Source={x:Reference codeBehind}, Path=BackgroundColor}"
                HorizontalOptions="{Binding Source={x:Reference codeBehind}, Path=HorizontalOptions}"
                VerticalOptions="{Binding Source={x:Reference codeBehind}, Path=VerticalOptions}" />
     </Grid>

--- a/src/IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro.csproj
+++ b/src/IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro.csproj
@@ -29,6 +29,9 @@
     <EmbeddedResource Update="Github112\Github112.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
+    <EmbeddedResource Update="Github120\Github120Page.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
     <EmbeddedResource Update="Github123\Github123.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>

--- a/src/IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/Github120/Github120Page.xaml
+++ b/src/IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/Github120/Github120Page.xaml
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             x:Class="DIPS.Xamarin.Forms.IssuesRepro.Github120.Github120Page"
+             xmlns:dxui="http://dips.xamarin.ui.com">
+    <!-- If both of these are showing when you are in dark mode, the bug is resolved -->
+    <StackLayout HorizontalOptions="Center"
+                 VerticalOptions="Center">
+        <dxui:TimePicker BackgroundColor="Red"/>
+        <dxui:DatePicker BackgroundColor="Red"/>
+    </StackLayout>
+</ContentPage>

--- a/src/IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/Github120/Github120Page.xaml.cs
+++ b/src/IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/Github120/Github120Page.xaml.cs
@@ -7,12 +7,12 @@ using System.Threading.Tasks;
 using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
-namespace DIPS.Xamarin.Forms.IssuesRepro.Github185
+namespace DIPS.Xamarin.Forms.IssuesRepro.Github120
 {
     [XamlCompilation(XamlCompilationOptions.Compile)]
-    public partial class Github185Page : ContentPage
+    public partial class Github120Page : ContentPage
     {
-        public Github185Page()
+        public Github120Page()
         {
             InitializeComponent();
         }

--- a/src/IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/Github185/Github185Page.xaml
+++ b/src/IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/Github185/Github185Page.xaml
@@ -5,7 +5,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:dxui="http://dips.xamarin.ui.com"
              mc:Ignorable="d"
-             x:Class="DIPS.Xamarin.Forms.IssuesRepro.HideMenuButton.Github185Page">
+             x:Class="DIPS.Xamarin.Forms.IssuesRepro.Github185.Github185Page">
     <dxui:ModalityLayout>
         <dxui:ModalityLayout.Behaviors>
             <dxui:FloatingActionMenuBehaviour XPosition="0.9"

--- a/src/IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/MainPage.xaml
+++ b/src/IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/MainPage.xaml
@@ -42,7 +42,10 @@
                 CommandParameter="159" />
         <Button Text="Github issue 185"
                 Command="{Binding NavigationCommand}"
-                CommandParameter="185" />
+                CommandParameter="185" /> 
+        <Button Text="Github issue 120"
+                Command="{Binding NavigationCommand}"
+                CommandParameter="120" />
     </StackLayout>
 
 </ContentPage>

--- a/src/IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/MainViewModel.cs
+++ b/src/IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/DIPS.Xamarin.Forms.IssuesRepro/MainViewModel.cs
@@ -1,5 +1,4 @@
 ﻿using System.Windows.Input;
-using DIPS.Xamarin.Forms.IssuesRepro.HideMenuButton;
 using Xamarin.Forms;
 
 namespace DIPS.Xamarin.Forms.IssuesRepro
@@ -32,7 +31,9 @@ namespace DIPS.Xamarin.Forms.IssuesRepro
             if (obj.Equals("159"))
                 Application.Current.MainPage.Navigation.PushAsync(new Github159.Github159());
             if (obj.Equals("185"))
-                Application.Current.MainPage.Navigation.PushAsync(new Github185Page());
+                Application.Current.MainPage.Navigation.PushAsync(new Github185.Github185Page());
+            if (obj.Equals("120"))
+                Application.Current.MainPage.Navigation.PushAsync(new Github120.Github120Page());
             ;
         }
     }


### PR DESCRIPTION
## Added / Fixed

- Time/DatePicker can now set their background color

## Todo List

- [X] I have tested on an Android device.
- [X] I have tested on an iOS device.
- [ ] I have added unit tests

>*Please add pictures / Gifs if possible*
>*Todo List can be checked by putting a `X` inside the brackets*
>*Remember to update our `wiki` after this PR is merged*

## References
- Fixes #120 