### PR TITLE
Added ShouldAutoClose to sheet and changed the behavior when dragging with autoclose

### DIFF
--- a/src/DIPS.Xamarin.UI/Controls/Sheet/SheetBehavior.cs
+++ b/src/DIPS.Xamarin.UI/Controls/Sheet/SheetBehavior.cs
@@ -708,11 +708,12 @@ namespace DIPS.Xamarin.UI.Controls.Sheet
         }
 
         /// <summary>
-        ///     Determines the minimum position of the sheet when it is visible.
+        ///     Determines the minimum position of the sheet.
         ///     This is a bindable property.
         /// </summary>
+        /// <remarks>This position is used to determine where the sheet will auto close if <see cref="ShouldAutoClose"/> is set to true</remarks>
+        /// <remarks>This position is used to determine where the sheet will snap to when <see cref="ShouldAutoClose"/> is set to false</remarks>
         /// <remarks>This will affect the size of the sheet if <see cref="Position" /> is set to 0</remarks>
-        /// <remarks>This will affect the people that are dragging the sheet</remarks>
         /// <remarks>The value have to be between 0 and 1.0 (percentage of the screen)</remarks>
         public double MinPosition
         {
@@ -1091,7 +1092,7 @@ namespace DIPS.Xamarin.UI.Controls.Sheet
             return newPosition;
         }
 
-        internal void UpdatePosition(double newYPosition)
+        internal async Task UpdatePosition(double newYPosition)
         {
             if (m_modalityLayout == null) return;
             if (m_sheetView == null) return;
@@ -1104,7 +1105,7 @@ namespace DIPS.Xamarin.UI.Controls.Sheet
             };
             if(!IsDragging)
             {
-                _ = TranslateBasedOnPosition(Position);
+                await TranslateBasedOnPosition(Position);
             }
         }
     }

--- a/src/DIPS.Xamarin.UI/Controls/Sheet/SheetBehavior.cs
+++ b/src/DIPS.Xamarin.UI/Controls/Sheet/SheetBehavior.cs
@@ -18,6 +18,12 @@ namespace DIPS.Xamarin.UI.Controls.Sheet
     [XamlCompilation(XamlCompilationOptions.Compile)]
     public class SheetBehavior : Behavior<ModalityLayout>, IModalityHandler
     {
+        private bool m_supressNextTranslation;
+        private bool m_fromIsOpenContext;
+        private ModalityLayout? m_modalityLayout;
+        private double? m_originalPosition = null;
+        private SheetView? m_sheetView;
+
         /// <summary>
         ///     <see cref="OnBeforeOpenCommand" />
         /// </summary>
@@ -353,13 +359,6 @@ namespace DIPS.Xamarin.UI.Controls.Sheet
         /// </summary>
         public static readonly BindableProperty ActionCommandParameterProperty =
             BindableProperty.Create(nameof(ActionCommandParameter), typeof(object), typeof(SheetBehavior));
-
-        private bool m_fromIsOpenContext;
-        private ModalityLayout? m_modalityLayout;
-
-        private double? m_originalPosition = null;
-
-        private SheetView? m_sheetView;
 
         /// <summary>
         ///     Parameter passed to <see cref="ActionCommand" />.
@@ -721,8 +720,6 @@ namespace DIPS.Xamarin.UI.Controls.Sheet
             set => SetValue(MinPositionProperty, value);
         }
 
-        private bool m_supressNextTranslation;
-
         /// <summary>
         ///     Determines the position of the sheet when it is visible.
         ///     This is a bindable property.
@@ -1022,14 +1019,20 @@ namespace DIPS.Xamarin.UI.Controls.Sheet
             if (m_sheetView == null) return;
             
 
-            if (MinPosition > MaxPosition) //Min position should be less than max position
+
+            if (MinPosition <= 0 || MinPosition > 1) //Min position should be between 0-1
             {
-                MinPosition = (double)MinPositionProperty.DefaultValue;
+                throw new XamlParseException($"{nameof(SheetBehavior)} {nameof(MinPosition)} has to be between 0 and 1");
             }
 
             if (MaxPosition <= 0 || MaxPosition > 1) //Max position should be between 0-1
             {
-                MaxPosition = (double)MaxPositionProperty.DefaultValue;
+                throw new XamlParseException($"{nameof(SheetBehavior)} {nameof(MaxPosition)} has to be between 0 and 1");
+            }
+
+            if (MinPosition > MaxPosition) //Min position should be less than max position
+            {
+                throw new XamlParseException($"{nameof(SheetBehavior)} {nameof(MinPosition)} can not be larger than {nameof(MaxPosition)}");
             }
 
 

--- a/src/DIPS.Xamarin.UI/Internal/Xaml/SheetView.xaml.cs
+++ b/src/DIPS.Xamarin.UI/Internal/Xaml/SheetView.xaml.cs
@@ -17,6 +17,7 @@ namespace DIPS.Xamarin.UI.Internal.xaml
         private readonly SheetBehavior m_sheetBehaviour;
 
         private double m_newY;
+        private double m_newYTranslation;
 
         /// <summary>
         ///     Constructs a <see cref="SheetView" />
@@ -57,15 +58,13 @@ namespace DIPS.Xamarin.UI.Internal.xaml
                 case GestureStatus.Running:
 
                     var translationY = Device.RuntimePlatform == Device.Android ? OuterSheetFrame.TranslationY : m_newY;
-                    var newYTranslation = e.TotalY + translationY;
+                    m_newYTranslation = e.TotalY + translationY;
                     //Hack to remove jitter from android 
                     if (Device.RuntimePlatform == Device.Android)
                     {
-                        e = new PanUpdatedEventArgs(e.StatusType, e.GestureId, 0, newYTranslation);
-                        newYTranslation = e.TotalY;
+                        e = new PanUpdatedEventArgs(e.StatusType, e.GestureId, 0, m_newYTranslation);
+                        m_newYTranslation = e.TotalY;
                     }
-
-                    m_sheetBehaviour.UpdatePosition(newYTranslation);
                     break;
                 case GestureStatus.Completed:
                     m_newY = SheetFrame.TranslationY;
@@ -77,6 +76,10 @@ namespace DIPS.Xamarin.UI.Internal.xaml
                     break;
                 default:
                     throw new ArgumentOutOfRangeException();
+            }
+            if(e.StatusType != GestureStatus.Started)
+            {
+                m_sheetBehaviour.UpdatePosition(m_newYTranslation);
             }
         }
 

--- a/src/DIPS.Xamarin.UI/Internal/Xaml/SheetView.xaml.cs
+++ b/src/DIPS.Xamarin.UI/Internal/Xaml/SheetView.xaml.cs
@@ -45,10 +45,10 @@ namespace DIPS.Xamarin.UI.Internal.xaml
         /// </summary>
         internal Frame SheetFrame => OuterSheetFrame;
 
-        private void OnDrag(object sender, PanUpdatedEventArgs e)
+        private async void OnDrag(object sender, PanUpdatedEventArgs e)
         {
             if (!m_sheetBehaviour.IsDraggable) return;
-            if (m_newY == 0) m_newY = SheetFrame.TranslationY;
+            if (m_newY == 0) m_newY = SheetFrame.TranslationY; //This variable is used to fix a iOS issue where an view element that you have a pan gesture on it and that is translating the same view element jitters
 
             switch (e.StatusType)
             {
@@ -67,7 +67,6 @@ namespace DIPS.Xamarin.UI.Internal.xaml
                     }
                     break;
                 case GestureStatus.Completed:
-                    m_newY = SheetFrame.TranslationY;
                     m_sheetBehaviour.IsDragging = false;
                     //Snap?
                     break;
@@ -79,8 +78,13 @@ namespace DIPS.Xamarin.UI.Internal.xaml
             }
             if(e.StatusType != GestureStatus.Started)
             {
-                m_sheetBehaviour.UpdatePosition(m_newYTranslation);
+                await m_sheetBehaviour.UpdatePosition(m_newYTranslation);
+                if (e.StatusType == GestureStatus.Completed) //Makes sure the jitter is removed on iOS
+                {
+                    m_newY = SheetFrame.TranslationY;
+                }
             }
+            
         }
 
         internal void Initialize()

--- a/src/Samples/DIPS.Xamarin.UI.Samples/Controls/Sheet/SheetPage.xaml
+++ b/src/Samples/DIPS.Xamarin.UI.Samples/Controls/Sheet/SheetPage.xaml
@@ -37,7 +37,8 @@
                                 ActionTitle="{Binding HasActionButton, Converter={dxui:BoolToObjectConverter FalseObject='', TrueObject=CanExecute}}"	
                                 BindingContextFactory="{Binding SheetViewModelFactory}"	
                                 CloseOnOverlayTapped="{Binding Source={x:Reference ShouldCloseOnOverlayTappedCheckbox}, Path=IsChecked}"	
-                                ShouldRememberPosition="{Binding ShouldRememberPosition}">
+                                ShouldRememberPosition="{Binding ShouldRememberPosition}"
+                                ShouldAutoClose="{Binding ShouldAutoClose}">
                 <StackLayout>
                     <Label Text="{Binding Source={x:Reference entry}, Path=Text}" />
                     <Label Text="{Binding Source={x:Reference entry}, Path=Text}" />
@@ -210,6 +211,15 @@
                             MaximumTrackColor="Tomato"
                             MinimumTrackColor="Tomato"
                             Value="{Binding Position}" />
+                </Grid>
+
+                <Grid ColumnDefinitions="*, *">
+                    <Label Grid.Column="0"
+                           Text="Should auto close"
+                           VerticalTextAlignment="Center" />
+                    <CheckBox Grid.Column="1"
+                              Grid.Row="0"
+                              IsChecked="{Binding ShouldAutoClose}" />
                 </Grid>
 
                 <Grid>

--- a/src/Samples/DIPS.Xamarin.UI.Samples/Controls/Sheet/SheetPage.xaml.cs
+++ b/src/Samples/DIPS.Xamarin.UI.Samples/Controls/Sheet/SheetPage.xaml.cs
@@ -39,7 +39,6 @@ namespace DIPS.Xamarin.UI.Samples.Controls.Sheet
         private bool m_shouldRememberPosition;
         private string m_contentColor;
         private string m_headerColor;
-        private bool m_cancelCanExecute = true;
         private string m_title;
         private bool m_hasActionButton;
 
@@ -169,6 +168,15 @@ namespace DIPS.Xamarin.UI.Samples.Controls.Sheet
             get => m_shouldRememberPosition;
             set => PropertyChanged.RaiseWhenSet(ref m_shouldRememberPosition, value);
         }
+
+        private bool m_shouldAutoClose = true;
+
+        public bool ShouldAutoClose
+        {
+            get => m_shouldAutoClose;
+            set => PropertyChanged.RaiseWhenSet(ref m_shouldAutoClose, value);
+        }
+
 
         public string ContentColor
         {


### PR DESCRIPTION
…in position when the sheets is not dragging anymore

## Added / Fixed

- The `MinPosition` is now used to determine when the sheet should close if `ShouldAutoClose` is set to true.
- `ShouldAutoClose` default is set to `true`
- The sheet does not auto close / snap into `MinPosition` until the user has finished dragging it.

## Todo List

- [X] I have tested on an Android device.
- [X] I have tested on an iOS device.
- [ ] I have added unit tests

## References
- Fixes #215 