### PR TITLE
The iOS datepicker is now synced when the user has closed the iOS datepicker but chosen to set date when done

### DIFF
--- a/src/DIPS.Xamarin.UI/Controls/DatePicker/DatePicker.xaml.cs
+++ b/src/DIPS.Xamarin.UI/Controls/DatePicker/DatePicker.xaml.cs
@@ -295,6 +295,12 @@ namespace DIPS.Xamarin.UI.Controls.DatePicker
         private void FormsDatePicker_Focused(object sender, FocusEventArgs e)
         {
             Opened?.Invoke(this, EventArgs.Empty);
+
+            //Make sure iOS date is syncronized if the user used the DateChangedStrategyiOS == iOSDateChangeStrategy.WhenDone but closed the date picker without picking
+            if (FormsDatePicker.Date.Date != Date.Date)
+            {
+                FormsDatePicker.Date = Date;
+            }
         }
 
         private void FormsDatePicker_Unfocused(object sender, FocusEventArgs e)


### PR DESCRIPTION
…icker after selected when using WhenDone strategy

## Added / Fixed

- The iOS datepicker is now synced when the user has closed the iOS datepicker but chosen to set date when done

## Todo List

- [X] I have tested on an Android device.
- [X] I have tested on an iOS device.
- [ ] I have added unit tests

>*Please add pictures / Gifs if possible*
>*Todo List can be checked by putting a `X` inside the brackets*
>*Remember to update our `wiki` after this PR is merged*
