### PR TITLE
Enables the user to change title font attributes and fix ios title boldness 

### DIFF
--- a/src/DIPS.Xamarin.UI/Controls/Sheet/SheetBehavior.cs
+++ b/src/DIPS.Xamarin.UI/Controls/Sheet/SheetBehavior.cs
@@ -209,7 +209,7 @@ namespace DIPS.Xamarin.UI.Controls.Sheet
             nameof(TitleColor),
             typeof(Color),
             typeof(SheetBehavior),
-            ColorPalette.TertiaryLight);
+            Label.TextColorProperty.DefaultValue);
 
         /// <summary>
         ///     <see cref="Title" />

--- a/src/DIPS.Xamarin.UI/Controls/Sheet/SheetBehavior.cs
+++ b/src/DIPS.Xamarin.UI/Controls/Sheet/SheetBehavior.cs
@@ -79,6 +79,23 @@ namespace DIPS.Xamarin.UI.Controls.Sheet
         /// </summary>
         public static readonly BindableProperty TitleSizeProperty = BindableProperty.Create(nameof(TitleSize), typeof(double), typeof(SheetBehavior), defaultValueCreator:b => Device.GetNamedSize(NamedSize.Medium, typeof(Label)));
 
+
+        /// <summary>
+        /// Title font attributes.
+        /// This is a bindable property.
+        /// </summary>
+        /// <remarks>Default is bold</remarks>
+        public FontAttributes TitleFontAttributes
+        {
+            get => (FontAttributes)GetValue(TitleFontAttributesProperty);
+            set => SetValue(TitleFontAttributesProperty, value);
+        }
+
+        /// <summary>
+        /// <see cref="TitleFontAttributes"/>
+        /// </summary>
+        public static readonly BindableProperty TitleFontAttributesProperty = BindableProperty.Create(nameof(TitleFontAttributes), typeof(FontAttributes), typeof(SheetBehavior), defaultValue: FontAttributes.Bold);
+
         /// <summary>
         /// The size of the label of the cancel button.
         /// This is a bindable property.

--- a/src/DIPS.Xamarin.UI/Internal/Xaml/SheetView.xaml
+++ b/src/DIPS.Xamarin.UI/Internal/Xaml/SheetView.xaml
@@ -76,7 +76,7 @@
                            Grid.Column="0"
                            Grid.ColumnSpan="3"
                            FontSize="{Binding TitleSize}"
-                           FontAttributes="Bold"
+                           FontAttributes="{Binding TitleFontAttributes}"
                            HorizontalOptions="Center"
                            Padding="10"
                            Text="{Binding Title}"

--- a/src/Samples/DIPS.Xamarin.UI.Samples/Controls/Sheet/SheetPage.xaml
+++ b/src/Samples/DIPS.Xamarin.UI.Samples/Controls/Sheet/SheetPage.xaml
@@ -16,8 +16,6 @@
     <dxui:ModalityLayout>
         <dxui:ModalityLayout.Behaviors>
             <dxui:SheetBehavior Title="{Binding Title}"
-                                TitleSize="Body"
-                                TitleFontAttributes="Bold"
                                 VerticalContentAlignment="{Binding VerticalContentAlignment}"
                                 ActionCommand="{Binding ActionCommand}"
                                 ActionTitle="{Binding HasActionButton, Converter={dxui:BoolToObjectConverter FalseObject='', TrueObject=CanExecute}}"

--- a/src/Samples/DIPS.Xamarin.UI.Samples/Controls/Sheet/SheetPage.xaml
+++ b/src/Samples/DIPS.Xamarin.UI.Samples/Controls/Sheet/SheetPage.xaml
@@ -16,6 +16,8 @@
     <dxui:ModalityLayout>
         <dxui:ModalityLayout.Behaviors>
             <dxui:SheetBehavior Title="{Binding Title}"
+                                TitleSize="Body"
+                                TitleFontAttributes="Bold"
                                 VerticalContentAlignment="{Binding VerticalContentAlignment}"
                                 ActionCommand="{Binding ActionCommand}"
                                 ActionTitle="{Binding HasActionButton, Converter={dxui:BoolToObjectConverter FalseObject='', TrueObject=CanExecute}}"


### PR DESCRIPTION
## Added / Fixed

- Enables the user to change title font attributes
    - Default is still **bold** as it was before.
- TitleTextColor default value is now the same as Label.TextColorProperty.DefaultValue. This resolve an issue on iOS where the label did not get bold when using a different color. This might be a Xam.Forms issue.

## Todo List

- [X] I have tested on an Android device.
- [X] I have tested on an iOS device.
- [ ] I have added unit tests

>*Please add pictures / Gifs if possible*
>*Todo List can be checked by putting a `X` inside the brackets*
>*Remember to update our `wiki` after this PR is merged*
