### PR TITLE
Removed exception throwing in string case converter

### DIFF
--- a/src/DIPS.Xamarin.UI.sln
+++ b/src/DIPS.Xamarin.UI.sln
@@ -106,6 +106,7 @@ Global
 		{CC0145B2-DB26-4C37-B52F-688B65D52EB4}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
 		{CC0145B2-DB26-4C37-B52F-688B65D52EB4}.Release|iPhoneSimulator.Deploy.0 = Release|Any CPU
 		{5D1BB5EC-52D3-4784-B20B-C4B022A496D0}.Debug|Any CPU.ActiveCfg = Debug|iPhone
+		{5D1BB5EC-52D3-4784-B20B-C4B022A496D0}.Debug|Any CPU.Build.0 = Debug|iPhone
 		{5D1BB5EC-52D3-4784-B20B-C4B022A496D0}.Debug|iPhone.ActiveCfg = Debug|iPhone
 		{5D1BB5EC-52D3-4784-B20B-C4B022A496D0}.Debug|iPhone.Build.0 = Debug|iPhone
 		{5D1BB5EC-52D3-4784-B20B-C4B022A496D0}.Debug|iPhone.Deploy.0 = Debug|iPhone

--- a/src/DIPS.Xamarin.UI/Controls/Toast/Toast.cs
+++ b/src/DIPS.Xamarin.UI/Controls/Toast/Toast.cs
@@ -48,7 +48,7 @@ namespace DIPS.Xamarin.UI.Controls.Toast
         /// <param name="options"><see cref="ToastOptions" /> to set for the Toast</param>
         /// <param name="layout"><see cref="ToastLayout" /> to set for the Toast</param>
         /// <returns>A void <c>Task</c></returns>
-        public static async Task DisplayToast(string text, ToastOptions options = null, ToastLayout layout = null)
+        public static async Task DisplayToast(string text, ToastOptions? options = null, ToastLayout? layout = null)
         {
             try
             {
@@ -57,7 +57,7 @@ namespace DIPS.Xamarin.UI.Controls.Toast
                     Initialize();
                 }
 
-                await ToastCore?.DisplayToast(text, options, layout)!;
+                await ToastCore?.DisplayToast(text, options ?? new ToastOptions(), layout ?? new ToastLayout())!;
             }
             catch (Exception ex)
             {

--- a/src/DIPS.Xamarin.UI/Controls/Toast/ToastCore.cs
+++ b/src/DIPS.Xamarin.UI/Controls/Toast/ToastCore.cs
@@ -204,13 +204,13 @@ namespace DIPS.Xamarin.UI.Controls.Toast
             await DisplayToast(text, toastOptions, layoutOptions);
         }
 
-        internal async Task DisplayToast(string text, ToastOptions options = null, ToastLayout layout = null)
+        internal async Task DisplayToast(string text, ToastOptions options, ToastLayout layout)
         {
             // get toast container
             var toastContainer = GetToastContainer();
 
             // toast view
-            var toastView = GetToast(text, options ?? new ToastOptions(), layout ?? new ToastLayout());
+            var toastView = GetToast(text, options, layout);
             toastContainer.Children.Add(toastView);
 
             // animate toast

--- a/src/DIPS.Xamarin.UI/Converters/ValueConverters/StringCaseConverter.cs
+++ b/src/DIPS.Xamarin.UI/Converters/ValueConverters/StringCaseConverter.cs
@@ -1,10 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
-using System.Text;
 using DIPS.Xamarin.UI.Extensions.Markup;
-using DIPS.Xamarin.UI.Internal.Utilities;
 using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
@@ -34,7 +31,7 @@ namespace DIPS.Xamarin.UI.Converters.ValueConverters
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
             if (!(value is string stringValue))
-                throw new XamlParseException("Input has to be of type string").WithXmlLineInfo(m_serviceProvider);
+                return null;
             if (stringValue == string.Empty)
                 return string.Empty;
 

--- a/src/Samples/DIPS.Xamarin.UI.Samples/Converters/ValueConverters/StringCaseConverterPage.xaml
+++ b/src/Samples/DIPS.Xamarin.UI.Samples/Converters/ValueConverters/StringCaseConverterPage.xaml
@@ -23,7 +23,8 @@
             </Grid.ColumnDefinitions>
             <Label Text="Using LocalizedString"
                    Grid.Column="0" />
-            <Label Text="{dxui:StringCase Input={x:Static SamplesResources:LocalizedStrings.TestString},StringCase=Upper}" />
+            <Label Grid.Column="1"
+                   Text="{dxui:StringCase Input={x:Static SamplesResources:LocalizedStrings.TestString},StringCase=Upper}" />
         </Grid>
         <Grid  Grid.Row="1">
             <Grid.ColumnDefinitions>
@@ -32,7 +33,8 @@
             </Grid.ColumnDefinitions>
             <Label Text="Using LocalizedString"
                    Grid.Column="0" />
-            <Label Text="{Binding MyString, Converter={dxui:StringCaseConverter StringCase=Upper}}" />
+            <Label Grid.Column="1" 
+                   Text="{Binding MyString, Converter={dxui:StringCaseConverter StringCase=Upper}, TargetNullValue='var null her'}" />
         </Grid>
     </Grid>
 </ContentPage>

--- a/src/Samples/DIPS.Xamarin.UI.Samples/Converters/ValueConverters/StringCaseConverterPage.xaml.cs
+++ b/src/Samples/DIPS.Xamarin.UI.Samples/Converters/ValueConverters/StringCaseConverterPage.xaml.cs
@@ -20,6 +20,6 @@ namespace DIPS.Xamarin.UI.Samples.Converters.ValueConverters
 
     public class StringCaseConverterViewModel
     {
-        public string MyString => "Test string";
+        public string MyString => "en test string";
     }
 }

--- a/src/Tests/DIPS.Xamarin.UI.Tests/Converters/ValueConverters/StringCaseConverterTests.cs
+++ b/src/Tests/DIPS.Xamarin.UI.Tests/Converters/ValueConverters/StringCaseConverterTests.cs
@@ -24,8 +24,7 @@ namespace DIPS.Xamarin.UI.Tests.Converters.ValueConverters
         [InlineData('c')]
         public void Convert_InvalidInput_ThrowsException(object input)
         {
-            Action act = () => m_stringCaseConverter.Convert(input, null, null, null);
-            act.Should().Throw<Exception>();
+            m_stringCaseConverter.Convert(input, null, null, null).Should().BeNull();
         }
 
 


### PR DESCRIPTION
## Added / Fixed

- Return `null` as that is a valid case for bindings. Then you can use `TargetNullValue` as well

## Todo List

- [ ] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have added unit tests

>*Please add pictures / Gifs if possible*
>*Todo List can be checked by putting a `X` inside the brackets*
>*Remember to update our `wiki` after this PR is merged*
