### PR TITLE
`IsOpen` is set before animations

### DIFF
--- a/src/DIPS.Xamarin.UI/Internal/Xaml/FloatingActionMenu.xaml.cs
+++ b/src/DIPS.Xamarin.UI/Internal/Xaml/FloatingActionMenu.xaml.cs
@@ -110,9 +110,12 @@ namespace DIPS.Xamarin.UI.Internal.Xaml
         {
             m_animationComplete = false;
 
+            m_isExpanded = !m_isExpanded;
+            m_behaviour.IsOpen = m_isExpanded;
+
             InvokeBeforeEvents();
 
-            if (!m_isExpanded)
+            if (m_isExpanded)
             {
                 DisplayOverlay();
             }
@@ -124,11 +127,11 @@ namespace DIPS.Xamarin.UI.Internal.Xaml
             var position = 0;
             foreach (var menuButton in Children.Where(menuButton => menuButton.IsVisible))
             {
-                TranslateMenuButton(menuButton, position, m_isExpanded);
+                TranslateMenuButton(menuButton, position, !m_isExpanded);
                 position++;
             }
 
-            ExpandButton.FadeTo(m_isExpanded ? .5 : 1, 250, Easing.CubicInOut);
+            ExpandButton.FadeTo(!m_isExpanded ? .5 : 1, 250, Easing.CubicInOut);
 
             var rotateTask = ExpandButton.RelRotateTo(180, 250, Easing.CubicInOut);
             await Task.Delay(250);
@@ -136,13 +139,12 @@ namespace DIPS.Xamarin.UI.Internal.Xaml
 
             InvokeAfterEvents();
 
-            m_isExpanded = !m_isExpanded;
             m_animationComplete = true;
         }
 
         private void InvokeAfterEvents()
         {
-            if (m_isExpanded)
+            if (!m_isExpanded)
             {
                 OnAfterClose?.Invoke(null, EventArgs.Empty);
                 m_behaviour.OnAfterCloseCommand?.Execute(m_behaviour.OnAfterCloseCommandParameter);
@@ -156,7 +158,7 @@ namespace DIPS.Xamarin.UI.Internal.Xaml
 
         private void InvokeBeforeEvents()
         {
-            if (m_isExpanded)
+            if (!m_isExpanded)
             {
                 OnBeforeClose?.Invoke(null, EventArgs.Empty);
                 m_behaviour.OnBeforeCloseCommand?.Execute(m_behaviour.OnBeforeCloseCommandParameter);
@@ -208,8 +210,6 @@ namespace DIPS.Xamarin.UI.Internal.Xaml
         {
             if (!m_animationComplete) return;
             await AnimateAll();
-
-            m_behaviour.IsOpen = m_isExpanded;
         }
 
         internal void AddTo(ModalityLayout layout)

--- a/src/Samples/DIPS.Xamarin.UI.Samples.Android/DIPS.Xamarin.UI.Samples.Android.csproj
+++ b/src/Samples/DIPS.Xamarin.UI.Samples.Android/DIPS.Xamarin.UI.Samples.Android.csproj
@@ -113,4 +113,9 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
+  <ProjectExtensions>
+    <VisualStudio>
+      <UserProperties TriggeredFromHotReload="False" />
+    </VisualStudio>
+  </ProjectExtensions>
 </Project>

--- a/src/Samples/DIPS.Xamarin.UI.Samples/Controls/FloatingActionMenu/FloatingActionMenuPage.xaml
+++ b/src/Samples/DIPS.Xamarin.UI.Samples/Controls/FloatingActionMenu/FloatingActionMenuPage.xaml
@@ -35,7 +35,8 @@
     <dxui:ModalityLayout x:Name="modalityLayout"
                          BackgroundColor="WhiteSmoke">
         <dxui:ModalityLayout.Behaviors>
-            <dxui:FloatingActionMenuBehaviour Size="60"
+            <dxui:FloatingActionMenuBehaviour x:Name="floatingActionMenuBehaviour"
+                                              Size="60"
                                               ExpandButtonBackgroundColor="LightSeaGreen"
                                               ExpandButtonText="Open"
                                               ExpandButtonFontSize="12"
@@ -160,6 +161,18 @@
                     </FormattedString>
                 </Label.FormattedText>
             </Label>
+
+            <Label x:Name="IsOpenLabel"
+                   FontSize="20"
+                   Margin="10">
+                <Label.FormattedText>
+                    <FormattedString>
+                        <Span Text="IsOpen: " />
+                        <Span Text="{Binding Source={x:Reference floatingActionMenuBehaviour}, Path=IsOpen}" />
+                    </FormattedString>
+                </Label.FormattedText>
+            </Label>
+
         </StackLayout>
     </dxui:ModalityLayout>
 </ContentPage>


### PR DESCRIPTION
## Added / Fixed

- The `IsOpen` property on floating menu is now toggled before the animation starts. 

Closes #252 

## Todo List

- [x] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have added unit tests

>*Please add pictures / Gifs if possible*
>*Todo List can be checked by putting a `X` inside the brackets*
>*Remember to update our `wiki` after this PR is merged*
