### PR TITLE
Supported  date/time format in en-GB

### DIFF
--- a/src/DIPS.Xamarin.UI/Converters/ValueConverters/DateAndTimeConverter.cs
+++ b/src/DIPS.Xamarin.UI/Converters/ValueConverters/DateAndTimeConverter.cs
@@ -58,11 +58,12 @@ namespace DIPS.Xamarin.UI.Converters.ValueConverters
             if (value == null) return string.Empty;
             if (!(value is DateTime dateTimeInput))
                 throw new XamlParseException("The input has to be of type DateTime").WithXmlLineInfo(m_serviceProvider);
-            return Format switch 
+            return Format switch
             {
-                DateAndTimeConverterFormat.Short => ConvertToShortFormat(dateTimeInput, culture), 
+                DateAndTimeConverterFormat.Short => ConvertToShortFormat(dateTimeInput, culture),
                 DateAndTimeConverterFormat.Text
-                => ConvertToTextFormat(dateTimeInput, culture), _ => string.Empty
+                    => ConvertToTextFormat(dateTimeInput, culture),
+                _ => string.Empty
             };
         }
 
@@ -75,8 +76,10 @@ namespace DIPS.Xamarin.UI.Converters.ValueConverters
 
         private static string ConvertToTextFormat(DateTime dateTimeInput, CultureInfo culture)
         {
-            var date = new DateConverter { Format = DateConverter.DateConverterFormat.Text }.Convert(dateTimeInput, null, null, culture);
-            var time = new TimeConverter { Format = TimeConverter.TimeConverterFormat.Default }.Convert(dateTimeInput, null, null, culture);
+            var date = new DateConverter {Format = DateConverter.DateConverterFormat.Text}.Convert(dateTimeInput, null,
+                null, culture);
+            var time = new TimeConverter {Format = TimeConverter.TimeConverterFormat.Default}.Convert(dateTimeInput,
+                null, null, culture);
 
             if (culture.IsNorwegian())
             {
@@ -84,15 +87,19 @@ namespace DIPS.Xamarin.UI.Converters.ValueConverters
                 {
                     return $"{date},{Space}kl{Space}{time}";
                 }
+
                 return $"{date}{Space}kl{Space}{time}";
             }
+
             return $"{date}{Space}{time}";
         }
 
         private static string ConvertToShortFormat(DateTime dateTimeInput, CultureInfo culture)
         {
-            var date = new DateConverter { Format = DateConverter.DateConverterFormat.Short }.Convert(dateTimeInput, null, null, culture);
-            var time = new TimeConverter { Format = TimeConverter.TimeConverterFormat.Default }.Convert(dateTimeInput, null, null, culture);
+            var date = new DateConverter {Format = DateConverter.DateConverterFormat.Short}.Convert(dateTimeInput, null,
+                null, culture);
+            var time = new TimeConverter {Format = TimeConverter.TimeConverterFormat.Default}.Convert(dateTimeInput,
+                null, null, culture);
 
             return culture.IsNorwegian() ? $"{date}{Space}kl{Space}{time}" : $"{date}{Space}{time}";
         }

--- a/src/DIPS.Xamarin.UI/Converters/ValueConverters/DateAndTimeConverter.cs
+++ b/src/DIPS.Xamarin.UI/Converters/ValueConverters/DateAndTimeConverter.cs
@@ -21,7 +21,7 @@ namespace DIPS.Xamarin.UI.Converters.ValueConverters
             /// <summary>
             ///     The short format, which is the same as <see cref="Default" /> to use during conversion
             /// </summary>
-            /// <example>12 Dec 1990 12:00 PM</example>
+            /// <example>12 Dec 1990 13:00</example>
             Short = 0,
 
             /// <summary>
@@ -32,7 +32,7 @@ namespace DIPS.Xamarin.UI.Converters.ValueConverters
             /// <summary>
             ///     A text format to use during conversion
             /// </summary>
-            /// <example>Today 12:00 PM</example>
+            /// <example>Today 13:00</example>
             Text,
         }
 

--- a/src/DIPS.Xamarin.UI/Converters/ValueConverters/DateConverter.cs
+++ b/src/DIPS.Xamarin.UI/Converters/ValueConverters/DateConverter.cs
@@ -62,11 +62,12 @@ namespace DIPS.Xamarin.UI.Converters.ValueConverters
             if (value == null) return string.Empty;
             if (!(value is DateTime dateTimeInput))
                 throw new XamlParseException("The input has to be of type DateTime").WithXmlLineInfo(m_serviceProvider);
-            return Format switch 
-            { 
-                    DateConverterFormat.Short => ConvertToDefaultDateTime(dateTimeInput, culture), 
-                    DateConverterFormat.Text =>
-                    ConvertDateTimeAsText(dateTimeInput, culture), _ => string.Empty
+            return Format switch
+            {
+                DateConverterFormat.Short => ConvertToDefaultDateTime(dateTimeInput, culture),
+                DateConverterFormat.Text =>
+                    ConvertDateTimeAsText(dateTimeInput, culture),
+                _ => string.Empty
             };
         }
 
@@ -83,6 +84,11 @@ namespace DIPS.Xamarin.UI.Converters.ValueConverters
 
             var month = GetMonthBasedOnCulture(dateTime, culture);
             var year = dateTime.ToString("yyyy", culture);
+            if (culture.ThreeLetterWindowsLanguageName.Equals("ENU"))
+            {
+                return $"{month}{Space}{day}{Space}{year}";
+            }
+
             return $"{day}{Space}{month}{Space}{year}";
         }
 
@@ -93,6 +99,11 @@ namespace DIPS.Xamarin.UI.Converters.ValueConverters
             {
                 day = day.TrimStart('0');
                 day += dateTime.GetEnglishDaySuffix();
+            }
+
+            if (culture.ThreeLetterWindowsLanguageName.Equals("ENU"))
+            {
+                day += ",";
             }
 
             if (culture.IsNorwegian())
@@ -122,6 +133,12 @@ namespace DIPS.Xamarin.UI.Converters.ValueConverters
 
             var month = GetMonthBasedOnCulture(dateTime, culture);
             var day = GetDayBasedOnCulture(dateTime, culture);
+
+            if (culture.ThreeLetterWindowsLanguageName.Equals("ENU"))
+            {
+                return $"{month}{Space}{day}";
+            }
+
             return $"{day}{Space}{month}";
         }
 

--- a/src/DIPS.Xamarin.UI/Converters/ValueConverters/TimeConverter.cs
+++ b/src/DIPS.Xamarin.UI/Converters/ValueConverters/TimeConverter.cs
@@ -23,7 +23,7 @@ namespace DIPS.Xamarin.UI.Converters.ValueConverters
             /// <summary>
             ///     The default time converter format
             /// </summary>
-            /// <example>12:00 PM</example>
+            /// <example>13:00</example>
             Default = 0,
         }
 
@@ -74,7 +74,7 @@ namespace DIPS.Xamarin.UI.Converters.ValueConverters
 
         private static string ConvertToDefaultFormat(DateTime dateTimeInput, CultureInfo culture)
         {
-            var time = dateTimeInput.ToString("hh:mm tt", culture);
+            var time = dateTimeInput.ToString("HH:mm", culture);
             if (culture.IsNorwegian())
             {
                 var hour = dateTimeInput.ToString("HH", culture);

--- a/src/DIPS.Xamarin.UI/Converters/ValueConverters/TimeConverter.cs
+++ b/src/DIPS.Xamarin.UI/Converters/ValueConverters/TimeConverter.cs
@@ -46,7 +46,8 @@ namespace DIPS.Xamarin.UI.Converters.ValueConverters
             var dateTimeInput = DateTime.MinValue;
             if (value == null) return string.Empty;
             if (!(value is DateTime) && !(value is TimeSpan))
-                throw new XamlParseException("The input has to be of type DateTime or TimeSpan").WithXmlLineInfo(m_serviceProvider);
+                throw new XamlParseException("The input has to be of type DateTime or TimeSpan").WithXmlLineInfo(
+                    m_serviceProvider);
 
             switch (value)
             {
@@ -80,6 +81,11 @@ namespace DIPS.Xamarin.UI.Converters.ValueConverters
                 var hour = dateTimeInput.ToString("HH", culture);
                 var minutes = dateTimeInput.ToString("mm", culture);
                 time = $"{hour}:{minutes}";
+            }
+
+            if (culture.ThreeLetterWindowsLanguageName.Equals("ENU"))
+            {
+                time = dateTimeInput.ToString("hh:mm tt", culture);
             }
 
             return time;

--- a/src/DIPS.Xamarin.UI/Extensions/CultureInfoExtensions.cs
+++ b/src/DIPS.Xamarin.UI/Extensions/CultureInfoExtensions.cs
@@ -14,7 +14,8 @@ namespace DIPS.Xamarin.UI.Extensions
         /// <param name="cultureInfo"></param>
         /// <returns></returns>
         public static bool IsNorwegian(this CultureInfo cultureInfo) =>
-            cultureInfo.TwoLetterISOLanguageName.Equals("nb") || cultureInfo.TwoLetterISOLanguageName.Equals("nn");
-
+            cultureInfo.ThreeLetterWindowsLanguageName.Equals("NOR") ||
+            cultureInfo.ThreeLetterWindowsLanguageName.Equals("NOB") ||
+            cultureInfo.ThreeLetterWindowsLanguageName.Equals("NNO");
     }
 }

--- a/src/Samples/DIPS.Xamarin.UI.Samples/Converters/ValueConverters/DateAndTimeConverterPage.xaml.cs
+++ b/src/Samples/DIPS.Xamarin.UI.Samples/Converters/ValueConverters/DateAndTimeConverterPage.xaml.cs
@@ -50,7 +50,7 @@ namespace DIPS.Xamarin.UI.Samples.Converters.ValueConverters
         public DateTime DateTime => Date + Time;
 
         public ICommand OpenLocaleMobileSettingsCommand { get; }
-        public string Locale => System.Threading.Thread.CurrentThread.CurrentCulture.TwoLetterISOLanguageName;
+        public string Locale => System.Threading.Thread.CurrentThread.CurrentCulture.ThreeLetterWindowsLanguageName;
 
         public event PropertyChangedEventHandler PropertyChanged;
     }

--- a/src/Samples/DIPS.Xamarin.UI.Samples/Converters/ValueConverters/DateConverterPage.xaml.cs
+++ b/src/Samples/DIPS.Xamarin.UI.Samples/Converters/ValueConverters/DateConverterPage.xaml.cs
@@ -44,6 +44,6 @@ namespace DIPS.Xamarin.UI.Samples.Converters.ValueConverters
 
         public ICommand OpenLocaleMobileSettingsCommand { get; }
 
-        public string Locale => System.Threading.Thread.CurrentThread.CurrentCulture.TwoLetterISOLanguageName;
+        public string Locale => System.Threading.Thread.CurrentThread.CurrentCulture.ThreeLetterWindowsLanguageName;
     }
 }

--- a/src/Samples/DIPS.Xamarin.UI.Samples/Converters/ValueConverters/TimeConverterPage.xaml.cs
+++ b/src/Samples/DIPS.Xamarin.UI.Samples/Converters/ValueConverters/TimeConverterPage.xaml.cs
@@ -39,6 +39,6 @@ namespace DIPS.Xamarin.UI.Samples.Converters.ValueConverters
         public event PropertyChangedEventHandler PropertyChanged;
 
         public ICommand OpenLocaleMobileSettingsCommand { get; }
-        public string Locale => System.Threading.Thread.CurrentThread.CurrentCulture.TwoLetterISOLanguageName;
+        public string Locale => System.Threading.Thread.CurrentThread.CurrentCulture.ThreeLetterWindowsLanguageName;
     }
 }

--- a/src/Tests/DIPS.Xamarin.UI.Tests/Converters/ValueConverters/DateAndTimeConverterTests.cs
+++ b/src/Tests/DIPS.Xamarin.UI.Tests/Converters/ValueConverters/DateAndTimeConverterTests.cs
@@ -43,10 +43,10 @@ namespace DIPS.Xamarin.UI.Tests.Converters.ValueConverters
             new List<object[]>()
             {
                 new object[] {"no", new DateTime(1991, 12, 12, 13, 12, 12), "12. des 1991 kl 13:12"},
-                new object[] {"en", new DateTime(1991, 12, 12, 10, 12, 12), "Dec 12th, 1991 10:12 AM"},
-                new object[] {"en", new DateTime(1991, 12, 12, 13, 12, 12), "Dec 12th, 1991 01:12 PM"},
-                new object[] {"enu", new DateTime(1991, 12, 12, 13, 12, 12), "12th Dec 1991 13:12"},
-                new object[] {"enu", new DateTime(1991, 12, 12, 10, 12, 00), "12th Dec 1991 10:12"},
+                new object[] {"en-us", new DateTime(1991, 12, 12, 10, 12, 12), "Dec 12th, 1991 10:12 AM"},
+                new object[] {"en-us", new DateTime(1991, 12, 12, 13, 12, 12), "Dec 12th, 1991 01:12 PM"},
+                new object[] {"en-gb", new DateTime(1991, 12, 12, 13, 12, 12), "12th Dec 1991 13:12"},
+                new object[] {"en-gb", new DateTime(1991, 12, 12, 10, 12, 00), "12th Dec 1991 10:12"},
             };
 
         [Theory]
@@ -64,14 +64,14 @@ namespace DIPS.Xamarin.UI.Tests.Converters.ValueConverters
         public static IEnumerable<object[]> TestDataForTextFormat =>
             new List<object[]>()
             {
-                new object[] {"enu", new DateTime(1990, 12, 12, 13, 00, 00), "Today 13:00"},
-                new object[] {"enu", new DateTime(1991, 12, 10, 13, 00, 00), "10th Dec 13:00"},
-                new object[] {"enu", new DateTime(1990, 12, 12, 13, 00, 00).AddDays(-1), "Yesterday 13:00"},
-                new object[] {"enu", new DateTime(1990, 12, 12, 13, 00, 00).AddDays(1), "Tomorrow 13:00"},
-                new object[] {"en", new DateTime(1990, 12, 12, 13, 00, 00), "Today 01:00 PM"},
-                new object[] {"en", new DateTime(1991, 12, 10, 13, 00, 00), "Dec 10th, 01:00 PM"},
-                new object[] {"en", new DateTime(1990, 12, 12, 13, 00, 00).AddDays(-1), "Yesterday 01:00 PM"},
-                new object[] {"en", new DateTime(1990, 12, 12, 13, 00, 00).AddDays(1), "Tomorrow 01:00 PM"},
+                new object[] {"en-gb", new DateTime(1990, 12, 12, 13, 00, 00), "Today 13:00"},
+                new object[] {"en-gb", new DateTime(1991, 12, 10, 13, 00, 00), "10th Dec 13:00"},
+                new object[] {"en-gb", new DateTime(1990, 12, 12, 13, 00, 00).AddDays(-1), "Yesterday 13:00"},
+                new object[] {"en-gb", new DateTime(1990, 12, 12, 13, 00, 00).AddDays(1), "Tomorrow 13:00"},
+                new object[] {"en-us", new DateTime(1990, 12, 12, 13, 00, 00), "Today 01:00 PM"},
+                new object[] {"en-us", new DateTime(1991, 12, 10, 13, 00, 00), "Dec 10th, 01:00 PM"},
+                new object[] {"en-us", new DateTime(1990, 12, 12, 13, 00, 00).AddDays(-1), "Yesterday 01:00 PM"},
+                new object[] {"en-us", new DateTime(1990, 12, 12, 13, 00, 00).AddDays(1), "Tomorrow 01:00 PM"},
                 new object[] {"no", new DateTime(1990, 12, 12, 13, 00, 00), "I dag, kl 13:00"},
                 new object[] {"no", new DateTime(1990, 12, 12, 13, 00, 00).AddDays(-1), "I går, kl 13:00"},
                 new object[] {"no", new DateTime(1990, 12, 12, 13, 00, 00).AddDays(1), "I morgen, kl 13:00"},

--- a/src/Tests/DIPS.Xamarin.UI.Tests/Converters/ValueConverters/DateAndTimeConverterTests.cs
+++ b/src/Tests/DIPS.Xamarin.UI.Tests/Converters/ValueConverters/DateAndTimeConverterTests.cs
@@ -8,7 +8,8 @@ using DIPS.Xamarin.UI.Tests.TestHelpers;
 using FluentAssertions;
 using Xamarin.Forms.Xaml;
 using Xunit;
-using DateAndTimeConverterFormat = DIPS.Xamarin.UI.Converters.ValueConverters.DateAndTimeConverter.DateAndTimeConverterFormat;
+using DateAndTimeConverterFormat =
+    DIPS.Xamarin.UI.Converters.ValueConverters.DateAndTimeConverter.DateAndTimeConverterFormat;
 
 namespace DIPS.Xamarin.UI.Tests.Converters.ValueConverters
 {
@@ -41,14 +42,17 @@ namespace DIPS.Xamarin.UI.Tests.Converters.ValueConverters
         public static IEnumerable<object[]> TestDataForShortFormat =>
             new List<object[]>()
             {
-                new object[] { "no", new DateTime(1991,12,12,12,12,12), "12. des 1991 kl 12:12" },
-                new object[] { "en", new DateTime(1991,12,12,13,00,00), "12th Dec 1991 13:00" },
-                new object[] { "en", new DateTime(1991,12,12,10,12,00), "12th Dec 1991 10:12" },
+                new object[] {"no", new DateTime(1991, 12, 12, 13, 12, 12), "12. des 1991 kl 13:12"},
+                new object[] {"en", new DateTime(1991, 12, 12, 10, 12, 12), "Dec 12th, 1991 10:12 AM"},
+                new object[] {"en", new DateTime(1991, 12, 12, 13, 12, 12), "Dec 12th, 1991 01:12 PM"},
+                new object[] {"enu", new DateTime(1991, 12, 12, 13, 12, 12), "12th Dec 1991 13:12"},
+                new object[] {"enu", new DateTime(1991, 12, 12, 10, 12, 00), "12th Dec 1991 10:12"},
             };
 
         [Theory]
         [MemberData(nameof(TestDataForShortFormat))]
-        public void Convert_WithShortFormat_WithCulture_CorrectFormat(string cultureName, DateTime date, string expected)
+        public void Convert_WithShortFormat_WithCulture_CorrectFormat(string cultureName, DateTime date,
+            string expected)
         {
             m_dateAndTimeConverter.Format = DateAndTimeConverterFormat.Short;
 
@@ -60,24 +64,29 @@ namespace DIPS.Xamarin.UI.Tests.Converters.ValueConverters
         public static IEnumerable<object[]> TestDataForTextFormat =>
             new List<object[]>()
             {
-                new object[] { "en", new DateTime(1990,12,12,13,00,00), "Today 13:00" },
-                new object[] { "en", new DateTime(1991,12,10,13,00,00), "10th Dec 13:00" },
-                new object[] { "en", new DateTime(1990,12,12,13,00,00).AddDays(-1), "Yesterday 13:00" },
-                new object[] { "en", new DateTime(1990,12,12,13,00,00).AddDays(1), "Tomorrow 13:00" },
-                new object[] { "no", new DateTime(1990,12,12,13,00,00), "I dag, kl 13:00" },
-                new object[] { "no", new DateTime(1990,12,12,13,00,00).AddDays(-1), "I går, kl 13:00" },
-                new object[] { "no", new DateTime(1990,12,12,13,00,00).AddDays(1), "I morgen, kl 13:00" },
-                new object[] { "no", new DateTime(1990,12,10,13,00,00), "10. des kl 13:00" }
+                new object[] {"enu", new DateTime(1990, 12, 12, 13, 00, 00), "Today 13:00"},
+                new object[] {"enu", new DateTime(1991, 12, 10, 13, 00, 00), "10th Dec 13:00"},
+                new object[] {"enu", new DateTime(1990, 12, 12, 13, 00, 00).AddDays(-1), "Yesterday 13:00"},
+                new object[] {"enu", new DateTime(1990, 12, 12, 13, 00, 00).AddDays(1), "Tomorrow 13:00"},
+                new object[] {"en", new DateTime(1990, 12, 12, 13, 00, 00), "Today 01:00 PM"},
+                new object[] {"en", new DateTime(1991, 12, 10, 13, 00, 00), "Dec 10th, 01:00 PM"},
+                new object[] {"en", new DateTime(1990, 12, 12, 13, 00, 00).AddDays(-1), "Yesterday 01:00 PM"},
+                new object[] {"en", new DateTime(1990, 12, 12, 13, 00, 00).AddDays(1), "Tomorrow 01:00 PM"},
+                new object[] {"no", new DateTime(1990, 12, 12, 13, 00, 00), "I dag, kl 13:00"},
+                new object[] {"no", new DateTime(1990, 12, 12, 13, 00, 00).AddDays(-1), "I går, kl 13:00"},
+                new object[] {"no", new DateTime(1990, 12, 12, 13, 00, 00).AddDays(1), "I morgen, kl 13:00"},
+                new object[] {"no", new DateTime(1990, 12, 10, 13, 00, 00), "10. des kl 13:00"}
             };
 
         [Theory]
         [MemberData(nameof(TestDataForTextFormat))]
-        public void Convert_WithTextFormat_WithDate_WithCulture_CorrectFormat(string cultureName, DateTime date, string expected)
+        public void Convert_WithTextFormat_WithDate_WithCulture_CorrectFormat(string cultureName, DateTime date,
+            string expected)
         {
             Clock.OverrideClock(m_now);
 
             m_dateAndTimeConverter.Format = DateAndTimeConverterFormat.Text;
-            InternalLocalizedStrings.Culture = new CultureInfo(cultureName);//To force localized strings
+            InternalLocalizedStrings.Culture = new CultureInfo(cultureName); //To force localized strings
 
             var actual = m_dateAndTimeConverter.Convert<string>(date, InternalLocalizedStrings.Culture);
             actual.Should().Be(expected);

--- a/src/Tests/DIPS.Xamarin.UI.Tests/Converters/ValueConverters/DateAndTimeConverterTests.cs
+++ b/src/Tests/DIPS.Xamarin.UI.Tests/Converters/ValueConverters/DateAndTimeConverterTests.cs
@@ -15,7 +15,7 @@ namespace DIPS.Xamarin.UI.Tests.Converters.ValueConverters
     [Collection("Sequential")] //This test class is using an static shared property that is used in other tests
     public class DateAndTimeConverterTests
     {
-        private readonly DateTime m_now = new DateTime(1990, 12, 12, 12, 00, 00);
+        private readonly DateTime m_now = new DateTime(1990, 12, 12, 13, 00, 00);
         private readonly DateAndTimeConverter m_dateAndTimeConverter = new DateAndTimeConverter();
 
         [Theory]
@@ -41,9 +41,9 @@ namespace DIPS.Xamarin.UI.Tests.Converters.ValueConverters
         public static IEnumerable<object[]> TestDataForShortFormat =>
             new List<object[]>()
             {
-                new object[] { "no", new DateTime(1991, 12, 12,12,12,12), "12. des 1991 kl 12:12" },
-                new object[] { "en", new DateTime(1991, 12, 12,12,12,12), "12th Dec 1991 12:12 PM" },
-                new object[] { "en", new DateTime(1991, 12, 12,10,12,12), "12th Dec 1991 10:12 AM" },
+                new object[] { "no", new DateTime(1991,12,12,12,12,12), "12. des 1991 kl 12:12" },
+                new object[] { "en", new DateTime(1991,12,12,13,00,00), "12th Dec 1991 13:00" },
+                new object[] { "en", new DateTime(1991,12,12,10,12,00), "12th Dec 1991 10:12" },
             };
 
         [Theory]
@@ -60,14 +60,14 @@ namespace DIPS.Xamarin.UI.Tests.Converters.ValueConverters
         public static IEnumerable<object[]> TestDataForTextFormat =>
             new List<object[]>()
             {
-                new object[] { "en", new DateTime(1990,12,12,12,12,00), "Today 12:12 PM" },
-                new object[] { "en", new DateTime(1991, 12, 10, 12, 12, 12), "10th Dec 12:12 PM" },
-                new object[] { "en", new DateTime(1990, 12, 12, 12, 12, 00).AddDays(-1), "Yesterday 12:12 PM" },
-                new object[] { "en", new DateTime(1990, 12, 12, 12, 12, 00).AddDays(1), "Tomorrow 12:12 PM" },
-                new object[] { "no", new DateTime(1990, 12, 12, 10, 12, 00), "I dag, kl 10:12" },
-                new object[] { "no", new DateTime(1990, 12, 12, 12, 12, 00).AddDays(-1), "I går, kl 12:12" },
-                new object[] { "no", new DateTime(1990, 12, 12, 12, 12, 00).AddDays(1), "I morgen, kl 12:12" },
-                new object[] { "no", new DateTime(1990, 12, 10, 09, 09, 00), "10. des kl 09:09" }
+                new object[] { "en", new DateTime(1990,12,12,13,00,00), "Today 13:00" },
+                new object[] { "en", new DateTime(1991,12,10,13,00,00), "10th Dec 13:00" },
+                new object[] { "en", new DateTime(1990,12,12,13,00,00).AddDays(-1), "Yesterday 13:00" },
+                new object[] { "en", new DateTime(1990,12,12,13,00,00).AddDays(1), "Tomorrow 13:00" },
+                new object[] { "no", new DateTime(1990,12,12,13,00,00), "I dag, kl 13:00" },
+                new object[] { "no", new DateTime(1990,12,12,13,00,00).AddDays(-1), "I går, kl 13:00" },
+                new object[] { "no", new DateTime(1990,12,12,13,00,00).AddDays(1), "I morgen, kl 13:00" },
+                new object[] { "no", new DateTime(1990,12,10,13,00,00), "10. des kl 13:00" }
             };
 
         [Theory]

--- a/src/Tests/DIPS.Xamarin.UI.Tests/Converters/ValueConverters/DateConverterTests.cs
+++ b/src/Tests/DIPS.Xamarin.UI.Tests/Converters/ValueConverters/DateConverterTests.cs
@@ -51,8 +51,8 @@ namespace DIPS.Xamarin.UI.Tests.Converters.ValueConverters
             new List<object[]>()
             {
                 new object[] {"no", new DateTime(1991, 12, 12), "12. des 1991"},
-                new object[] {"enu", new DateTime(1991, 12, 12), "12th Dec 1991"},
-                new object[] {"en", new DateTime(1991, 12, 12), "Dec 12th, 1991"},
+                new object[] {"en-gb", new DateTime(1991, 12, 12), "12th Dec 1991"},
+                new object[] {"en-us", new DateTime(1991, 12, 12), "Dec 12th, 1991"},
             };
 
         [Theory]
@@ -73,14 +73,14 @@ namespace DIPS.Xamarin.UI.Tests.Converters.ValueConverters
             var date = new DateTime(1990, 12, 03);
 
             //To force localized strings
-            if (CultureInfo.CurrentCulture.Equals("en"))
+            if (CultureInfo.CurrentCulture.Equals("en-us"))
             {
-                InternalLocalizedStrings.Culture = new CultureInfo("en");
+                InternalLocalizedStrings.Culture = new CultureInfo("en-us");
                 m_expected = "Dec 3rd, 1990";
             }
             else
             {
-                InternalLocalizedStrings.Culture = new CultureInfo("enu");
+                InternalLocalizedStrings.Culture = new CultureInfo("en-gb");
                 m_expected = "3rd Dec 1990";
             }
 
@@ -92,14 +92,14 @@ namespace DIPS.Xamarin.UI.Tests.Converters.ValueConverters
         public static IEnumerable<object[]> TestDataForTextFormat =>
             new List<object[]>()
             {
-                new object[] {"en", new DateTime(1990, 12, 12), "Today"},
-                new object[] {"en", new DateTime(1990, 12, 12).AddDays(-1), "Yesterday"},
-                new object[] {"en", new DateTime(1990, 12, 12).AddDays(1), "Tomorrow"},
-                new object[] {"en", new DateTime(1990, 12, 10), "Dec 10th,"},
-                new object[] {"enu", new DateTime(1990, 12, 12), "Today"},
-                new object[] {"enu", new DateTime(1990, 12, 12).AddDays(-1), "Yesterday"},
-                new object[] {"enu", new DateTime(1990, 12, 12).AddDays(1), "Tomorrow"},
-                new object[] {"enu", new DateTime(1990, 12, 10), "10th Dec"},
+                new object[] {"en-us", new DateTime(1990, 12, 12), "Today"},
+                new object[] {"en-us", new DateTime(1990, 12, 12).AddDays(-1), "Yesterday"},
+                new object[] {"en-us", new DateTime(1990, 12, 12).AddDays(1), "Tomorrow"},
+                new object[] {"en-us", new DateTime(1990, 12, 10), "Dec 10th,"},
+                new object[] {"en-gb", new DateTime(1990, 12, 12), "Today"},
+                new object[] { "en-gb", new DateTime(1990, 12, 12).AddDays(-1), "Yesterday"},
+                new object[] { "en-gb", new DateTime(1990, 12, 12).AddDays(1), "Tomorrow"},
+                new object[] { "en-gb", new DateTime(1990, 12, 10), "10th Dec"},
                 new object[] {"no", new DateTime(1990, 12, 12), "I dag"},
                 new object[] {"no", new DateTime(1990, 12, 12).AddDays(-1), "I går"},
                 new object[] {"no", new DateTime(1990, 12, 12).AddDays(1), "I morgen"},

--- a/src/Tests/DIPS.Xamarin.UI.Tests/Converters/ValueConverters/DateConverterTests.cs
+++ b/src/Tests/DIPS.Xamarin.UI.Tests/Converters/ValueConverters/DateConverterTests.cs
@@ -15,8 +15,9 @@ namespace DIPS.Xamarin.UI.Tests.Converters.ValueConverters
     [Collection("Sequential")] //This test class is using an static shared property that is used in other tests
     public class DateConverterTests
     {
-        private readonly DateTime m_now = new DateTime(1990, 12, 12, 12, 00,00);
+        private readonly DateTime m_now = new DateTime(1990, 12, 12, 12, 00, 00);
         private readonly DateConverter m_dateConverter = new DateConverter();
+        private string m_expected;
 
         [Theory]
         [InlineData(0)]
@@ -49,57 +50,72 @@ namespace DIPS.Xamarin.UI.Tests.Converters.ValueConverters
         public static IEnumerable<object[]> TestDataForShortFormat =>
             new List<object[]>()
             {
-                new object[] { "no", new DateTime(1991, 12, 12), "12. des 1991" },
-                new object[] { "en", new DateTime(1991, 12, 12), "12th Dec 1991" },
+                new object[] {"no", new DateTime(1991, 12, 12), "12. des 1991"},
+                new object[] {"enu", new DateTime(1991, 12, 12), "12th Dec 1991"},
+                new object[] {"en", new DateTime(1991, 12, 12), "Dec 12th, 1991"},
             };
 
         [Theory]
         [MemberData(nameof(TestDataForShortFormat))]
-        public void Convert_WithShortFormat_WithCulture_CorrectFormat(string cultureName, DateTime date, string expected)
+        public void Convert_WithShortFormat_WithCulture_CorrectFormat(string cultureName, DateTime date,
+            string expected)
         {
             Clock.OverrideClock(date);
 
             m_dateConverter.Format = DateConverterFormat.Short;
-
             var actual = m_dateConverter.Convert<string>(date, new CultureInfo(cultureName));
-
             actual.Should().Be(expected);
         }
 
         [Fact]
         public void Converter_WithEnglishCulture_DayLessThanTen_ShouldNotIncludeFirstZero()
         {
-            InternalLocalizedStrings.Culture = new CultureInfo("en");//To force localized strings
             var date = new DateTime(1990, 12, 03);
-            var expected = "3rd Dec 1990";
+
+            //To force localized strings
+            if (CultureInfo.CurrentCulture.Equals("en"))
+            {
+                InternalLocalizedStrings.Culture = new CultureInfo("en");
+                m_expected = "Dec 3rd, 1990";
+            }
+            else
+            {
+                InternalLocalizedStrings.Culture = new CultureInfo("enu");
+                m_expected = "3rd Dec 1990";
+            }
 
             var actual = m_dateConverter.Convert<string>(date, InternalLocalizedStrings.Culture);
 
-            actual.Should().Be(expected);
+            actual.Should().Be(m_expected);
         }
 
         public static IEnumerable<object[]> TestDataForTextFormat =>
             new List<object[]>()
             {
-                new object[] { "en", new DateTime(1990,12,12), "Today" },
-                new object[] { "en", new DateTime(1990, 12, 12).AddDays(-1), "Yesterday" },
-                new object[] { "en", new DateTime(1990, 12, 12).AddDays(1), "Tomorrow" },
-                new object[] { "en", new DateTime(1990, 12, 10), "10th Dec" },
-                new object[] { "no", new DateTime(1990, 12, 12), "I dag" },
-                new object[] { "no", new DateTime(1990, 12, 12).AddDays(-1), "I går" },
-                new object[] { "no", new DateTime(1990, 12, 12).AddDays(1), "I morgen" },
-                new object[] { "no", new DateTime(1990, 12, 10), "10. des" }
+                new object[] {"en", new DateTime(1990, 12, 12), "Today"},
+                new object[] {"en", new DateTime(1990, 12, 12).AddDays(-1), "Yesterday"},
+                new object[] {"en", new DateTime(1990, 12, 12).AddDays(1), "Tomorrow"},
+                new object[] {"en", new DateTime(1990, 12, 10), "Dec 10th,"},
+                new object[] {"enu", new DateTime(1990, 12, 12), "Today"},
+                new object[] {"enu", new DateTime(1990, 12, 12).AddDays(-1), "Yesterday"},
+                new object[] {"enu", new DateTime(1990, 12, 12).AddDays(1), "Tomorrow"},
+                new object[] {"enu", new DateTime(1990, 12, 10), "10th Dec"},
+                new object[] {"no", new DateTime(1990, 12, 12), "I dag"},
+                new object[] {"no", new DateTime(1990, 12, 12).AddDays(-1), "I går"},
+                new object[] {"no", new DateTime(1990, 12, 12).AddDays(1), "I morgen"},
+                new object[] {"no", new DateTime(1990, 12, 10), "10. des"}
             };
 
         [Theory]
         [MemberData(nameof(TestDataForTextFormat))]
-        public void Convert_WithTextFormat_WithDate_WithCulture_CorrectFormat(string cultureName, DateTime date, string expected)
+        public void Convert_WithTextFormat_WithDate_WithCulture_CorrectFormat(string cultureName, DateTime date,
+            string expected)
         {
             Clock.OverrideClock(m_now);
 
             m_dateConverter.Format = DateConverterFormat.Text;
 
-            InternalLocalizedStrings.Culture = new CultureInfo(cultureName);//To force localized strings
+            InternalLocalizedStrings.Culture = new CultureInfo(cultureName); //To force localized strings
 
             var actual = m_dateConverter.Convert<string>(date, InternalLocalizedStrings.Culture);
             actual.Should().Be(expected);

--- a/src/Tests/DIPS.Xamarin.UI.Tests/Converters/ValueConverters/TimeConverterTests.cs
+++ b/src/Tests/DIPS.Xamarin.UI.Tests/Converters/ValueConverters/TimeConverterTests.cs
@@ -41,7 +41,7 @@ namespace DIPS.Xamarin.UI.Tests.Converters.ValueConverters
             {
                 new object[] { "nb", new TimeSpan(09,12,00), "09:12" },
                 new object[] { "nb", new TimeSpan(21,12,00), "21:12" },
-                new object[] { "en", new TimeSpan(09,12,00), "21:12" },
+                new object[] { "en", new TimeSpan(09,12,00), "09:12" },
                 new object[] { "en", new TimeSpan(21,12,00), "21:12" },
             };
 

--- a/src/Tests/DIPS.Xamarin.UI.Tests/Converters/ValueConverters/TimeConverterTests.cs
+++ b/src/Tests/DIPS.Xamarin.UI.Tests/Converters/ValueConverters/TimeConverterTests.cs
@@ -41,10 +41,10 @@ namespace DIPS.Xamarin.UI.Tests.Converters.ValueConverters
             {
                 new object[] {"no", new TimeSpan(09, 12, 00), "09:12"},
                 new object[] {"no", new TimeSpan(21, 12, 00), "21:12"},
-                new object[] {"enu", new TimeSpan(09, 12, 00), "09:12"},
-                new object[] {"enu", new TimeSpan(21, 12, 00), "21:12"},
-                new object[] {"en", new TimeSpan(09, 12, 00), "09:12 AM"},
-                new object[] {"en", new TimeSpan(21, 12, 00), "09:12 PM"},
+                new object[] {"en-gb", new TimeSpan(09, 12, 00), "09:12"},
+                new object[] {"en-gb", new TimeSpan(21, 12, 00), "21:12"},
+                new object[] {"en-us", new TimeSpan(09, 12, 00), "09:12 AM"},
+                new object[] {"en-us", new TimeSpan(21, 12, 00), "09:12 PM"},
             };
 
         [Theory]

--- a/src/Tests/DIPS.Xamarin.UI.Tests/Converters/ValueConverters/TimeConverterTests.cs
+++ b/src/Tests/DIPS.Xamarin.UI.Tests/Converters/ValueConverters/TimeConverterTests.cs
@@ -67,7 +67,7 @@ namespace DIPS.Xamarin.UI.Tests.Converters.ValueConverters
             Clock.OverrideClock(date);
             m_timeConverter.Format = TimeConverterFormat.Default;
 
-            var actual = m_timeConverter.Convert<string>(date, new CultureInfo("enu"));
+            var actual = m_timeConverter.Convert<string>(date, new CultureInfo("en-gb"));
 
             actual.Should().Be(expected);
         }

--- a/src/Tests/DIPS.Xamarin.UI.Tests/Converters/ValueConverters/TimeConverterTests.cs
+++ b/src/Tests/DIPS.Xamarin.UI.Tests/Converters/ValueConverters/TimeConverterTests.cs
@@ -41,8 +41,8 @@ namespace DIPS.Xamarin.UI.Tests.Converters.ValueConverters
             {
                 new object[] { "nb", new TimeSpan(09,12,00), "09:12" },
                 new object[] { "nb", new TimeSpan(21,12,00), "21:12" },
-                new object[] { "en", new TimeSpan(09,12,00), "09:12 AM" },
-                new object[] { "en", new TimeSpan(21,12,00), "09:12 PM" },
+                new object[] { "en", new TimeSpan(09,12,00), "21:12" },
+                new object[] { "en", new TimeSpan(21,12,00), "21:12" },
             };
 
         [Theory]
@@ -59,8 +59,8 @@ namespace DIPS.Xamarin.UI.Tests.Converters.ValueConverters
         [Fact]
         public void Convert_WithShortFormat_WithDateTime_CorrectFormat()
         {
-            var expected = "12:12 PM";
-            var date = new DateTime(1991, 12, 12, 12, 12, 12);
+            var expected = "13:00";
+            var date = new DateTime(1991, 12, 12, 13, 00, 00);
             Clock.OverrideClock(date);
             m_timeConverter.Format = TimeConverterFormat.Default;
 

--- a/src/Tests/DIPS.Xamarin.UI.Tests/Converters/ValueConverters/TimeConverterTests.cs
+++ b/src/Tests/DIPS.Xamarin.UI.Tests/Converters/ValueConverters/TimeConverterTests.cs
@@ -39,15 +39,18 @@ namespace DIPS.Xamarin.UI.Tests.Converters.ValueConverters
         public static IEnumerable<object[]> TestDataForDefaultFormat =>
             new List<object[]>()
             {
-                new object[] { "nb", new TimeSpan(09,12,00), "09:12" },
-                new object[] { "nb", new TimeSpan(21,12,00), "21:12" },
-                new object[] { "en", new TimeSpan(09,12,00), "09:12" },
-                new object[] { "en", new TimeSpan(21,12,00), "21:12" },
+                new object[] {"NOR", new TimeSpan(09, 12, 00), "09:12"},
+                new object[] {"NOR", new TimeSpan(21, 12, 00), "21:12"},
+                new object[] {"ENU", new TimeSpan(09, 12, 00), "09:12"},
+                new object[] {"ENU", new TimeSpan(21, 12, 00), "21:12"},
+                new object[] {"ENG", new TimeSpan(09, 12, 00), "09:12 AM"},
+                new object[] {"ENG", new TimeSpan(21, 12, 00), "09:12 PM"},
             };
 
         [Theory]
         [MemberData(nameof(TestDataForDefaultFormat))]
-        public void Convert_WithDefaultFormat_WithCulture_CorrectFormat(string cultureName, TimeSpan time, string expected)
+        public void Convert_WithDefaultFormat_WithCulture_CorrectFormat(string cultureName, TimeSpan time,
+            string expected)
         {
             m_timeConverter.Format = TimeConverterFormat.Default;
 
@@ -64,7 +67,7 @@ namespace DIPS.Xamarin.UI.Tests.Converters.ValueConverters
             Clock.OverrideClock(date);
             m_timeConverter.Format = TimeConverterFormat.Default;
 
-            var actual = m_timeConverter.Convert<string>(date, new CultureInfo("en"));
+            var actual = m_timeConverter.Convert<string>(date, new CultureInfo("ENU"));
 
             actual.Should().Be(expected);
         }

--- a/src/Tests/DIPS.Xamarin.UI.Tests/Converters/ValueConverters/TimeConverterTests.cs
+++ b/src/Tests/DIPS.Xamarin.UI.Tests/Converters/ValueConverters/TimeConverterTests.cs
@@ -39,12 +39,12 @@ namespace DIPS.Xamarin.UI.Tests.Converters.ValueConverters
         public static IEnumerable<object[]> TestDataForDefaultFormat =>
             new List<object[]>()
             {
-                new object[] {"NOR", new TimeSpan(09, 12, 00), "09:12"},
-                new object[] {"NOR", new TimeSpan(21, 12, 00), "21:12"},
-                new object[] {"ENU", new TimeSpan(09, 12, 00), "09:12"},
-                new object[] {"ENU", new TimeSpan(21, 12, 00), "21:12"},
-                new object[] {"ENG", new TimeSpan(09, 12, 00), "09:12 AM"},
-                new object[] {"ENG", new TimeSpan(21, 12, 00), "09:12 PM"},
+                new object[] {"no", new TimeSpan(09, 12, 00), "09:12"},
+                new object[] {"no", new TimeSpan(21, 12, 00), "21:12"},
+                new object[] {"enu", new TimeSpan(09, 12, 00), "09:12"},
+                new object[] {"enu", new TimeSpan(21, 12, 00), "21:12"},
+                new object[] {"en", new TimeSpan(09, 12, 00), "09:12 AM"},
+                new object[] {"en", new TimeSpan(21, 12, 00), "09:12 PM"},
             };
 
         [Theory]
@@ -67,7 +67,7 @@ namespace DIPS.Xamarin.UI.Tests.Converters.ValueConverters
             Clock.OverrideClock(date);
             m_timeConverter.Format = TimeConverterFormat.Default;
 
-            var actual = m_timeConverter.Convert<string>(date, new CultureInfo("ENU"));
+            var actual = m_timeConverter.Convert<string>(date, new CultureInfo("enu"));
 
             actual.Should().Be(expected);
         }


### PR DESCRIPTION
##  Fixed

- Fixed date/time format in EN-GB
eg: 3rd Dec 2020 13:00

- Fixed date/time format in EN-US
eg: Dec 3rd, 2020 1:00 PM

## Todo List

- [X] I have tested on an Android device.
- [X] I have tested on an iOS device.
- [X] I have added unit tests
