### PR TITLE
Add ToastContainer wrapper

### DIFF
--- a/src/DIPS.Xamarin.UI/Controls/Toast/ToastCore.cs
+++ b/src/DIPS.Xamarin.UI/Controls/Toast/ToastCore.cs
@@ -60,7 +60,7 @@ namespace DIPS.Xamarin.UI.Controls.Toast
             // get current page
             m_currentPageWithToast = GetCurrentContentPage();
 
-            // try get toast container
+            // try get registered toast container
             var toastContainer = FindByName(m_currentPageWithToast.Id.ToString());
             if (toastContainer != null) // found toast container
             {
@@ -72,8 +72,21 @@ namespace DIPS.Xamarin.UI.Controls.Toast
                     toastContainer.Children.Remove(oldToast);
                 }
             }
-            else // no toast container
+            else // no registered toast container
             {
+                //Get existing toast container 
+                var componentsList = m_currentPageWithToast.LogicalChildren.Where(w => w.GetType() == typeof(ToastContainer)).ToList();
+                if (componentsList.Any())
+                {
+                    var toastContainerWrapper = (ToastContainer)componentsList.First();
+                    var containerList = toastContainerWrapper.Children.Where(w => w.GetType() == typeof(Grid));
+                    toastContainer = (Grid)containerList.First();
+
+                    RegisterName(m_currentPageWithToast.Id.ToString(), toastContainer);
+                    m_currentPageWithToast.Disappearing += OnPageDisappearing;
+                    return toastContainer;
+                }
+                // no any toast container
                 // create and register toast container
                 toastContainer = new Grid();
                 RegisterName(m_currentPageWithToast.Id.ToString(), toastContainer);

--- a/src/DIPS.Xamarin.UI/Controls/Toast/ToastCore.cs
+++ b/src/DIPS.Xamarin.UI/Controls/Toast/ToastCore.cs
@@ -3,9 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using DIPS.Xamarin.UI.Extensions;
 using DIPS.Xamarin.UI.Internal.Xaml;
-using Xamarin.Essentials;
 using Xamarin.Forms;
 
 namespace DIPS.Xamarin.UI.Controls.Toast
@@ -75,17 +73,13 @@ namespace DIPS.Xamarin.UI.Controls.Toast
             else // no registered toast container
             {
                 //Get existing toast container 
-                var componentsList = m_currentPageWithToast.LogicalChildren.Where(w => w.GetType() == typeof(ToastContainer)).ToList();
-                if (componentsList.Any())
+                if (m_currentPageWithToast.Content is ToastContainer currentToastContainer)
                 {
-                    var toastContainerWrapper = (ToastContainer)componentsList.First();
-                    var containerList = toastContainerWrapper.Children.Where(w => w.GetType() == typeof(Grid));
-                    toastContainer = (Grid)containerList.First();
-
-                    RegisterName(m_currentPageWithToast.Id.ToString(), toastContainer);
+                    RegisterName(m_currentPageWithToast.Id.ToString(), currentToastContainer);
                     m_currentPageWithToast.Disappearing += OnPageDisappearing;
-                    return toastContainer;
+                    return currentToastContainer;
                 }
+
                 // no any toast container
                 // create and register toast container
                 toastContainer = new Grid();

--- a/src/DIPS.Xamarin.UI/Internal/Xaml/ToastContainer.xaml
+++ b/src/DIPS.Xamarin.UI/Internal/Xaml/ToastContainer.xaml
@@ -1,13 +1,8 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
-<ContentView xmlns="http://xamarin.com/schemas/2014/forms"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="DIPS.Xamarin.UI.Internal.Xaml.ToastContainer"
-             x:Name="pageCodeBehind">
-    <ContentView.Content>
-        <Grid BackgroundColor="Transparent">
-            <ContentView
-                Content="{Binding Source={x:Reference pageCodeBehind}, Path=MainContent}" />
-        </Grid>
-    </ContentView.Content>
-</ContentView>
+<Grid xmlns="http://xamarin.com/schemas/2014/forms"
+      xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+      x:Class="DIPS.Xamarin.UI.Internal.Xaml.ToastContainer"
+      BackgroundColor="Transparent">
+</Grid>
+    

--- a/src/DIPS.Xamarin.UI/Internal/Xaml/ToastContainer.xaml
+++ b/src/DIPS.Xamarin.UI/Internal/Xaml/ToastContainer.xaml
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+
+<ContentView xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="DIPS.Xamarin.UI.Internal.Xaml.ToastContainer"
+             x:Name="pageCodeBehind">
+    <ContentView.Content>
+        <Grid BackgroundColor="Transparent">
+            <ContentView
+                Content="{Binding Source={x:Reference pageCodeBehind}, Path=MainContent}" />
+        </Grid>
+    </ContentView.Content>
+</ContentView>

--- a/src/DIPS.Xamarin.UI/Internal/Xaml/ToastContainer.xaml.cs
+++ b/src/DIPS.Xamarin.UI/Internal/Xaml/ToastContainer.xaml.cs
@@ -3,24 +3,40 @@ using Xamarin.Forms.Xaml;
 
 namespace DIPS.Xamarin.UI.Internal.Xaml
 {
+    /// <summary>
+    ///     Toast container that act as a wrapper to the presented view
+    /// </summary>
     [ContentProperty(nameof(MainContent))]
     [XamlCompilation(XamlCompilationOptions.Compile)]
     public partial class ToastContainer : ContentView
     {
-        public static readonly BindableProperty MainContentProperty = BindableProperty.Create(
-            nameof(MainContent),
-            typeof(View),
-            typeof(ToastContainer));
-
         public ToastContainer()
         {
             InitializeComponent();
         }
 
+        #region Bindable Properties
+
+        /// <summary>
+        ///     Bindable property for <see cref="MainContent" />
+        /// </summary>
+        public static readonly BindableProperty MainContentProperty = BindableProperty.Create(
+            nameof(MainContent),
+            typeof(View),
+            typeof(ToastContainer));
+
+        #endregion
+
+        #region Public Properties
+
+        /// <summary>
+        ///     Gets or sets the MainContent for the ToastContainer. This is a bindable property.
+        /// </summary>
         public View MainContent
         {
             get => (View)GetValue(MainContentProperty);
             set => SetValue(MainContentProperty, value);
         }
+        #endregion
     }
 }

--- a/src/DIPS.Xamarin.UI/Internal/Xaml/ToastContainer.xaml.cs
+++ b/src/DIPS.Xamarin.UI/Internal/Xaml/ToastContainer.xaml.cs
@@ -1,4 +1,4 @@
-﻿using Xamarin.Forms;
+using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 namespace DIPS.Xamarin.UI.Internal.Xaml
@@ -6,37 +6,12 @@ namespace DIPS.Xamarin.UI.Internal.Xaml
     /// <summary>
     ///     Toast container that act as a wrapper to the presented view
     /// </summary>
-    [ContentProperty(nameof(MainContent))]
     [XamlCompilation(XamlCompilationOptions.Compile)]
-    public partial class ToastContainer : ContentView
+    public partial class ToastContainer : Grid
     {
         public ToastContainer()
         {
             InitializeComponent();
         }
-
-        #region Bindable Properties
-
-        /// <summary>
-        ///     Bindable property for <see cref="MainContent" />
-        /// </summary>
-        public static readonly BindableProperty MainContentProperty = BindableProperty.Create(
-            nameof(MainContent),
-            typeof(View),
-            typeof(ToastContainer));
-
-        #endregion
-
-        #region Public Properties
-
-        /// <summary>
-        ///     Gets or sets the MainContent for the ToastContainer. This is a bindable property.
-        /// </summary>
-        public View MainContent
-        {
-            get => (View)GetValue(MainContentProperty);
-            set => SetValue(MainContentProperty, value);
-        }
-        #endregion
     }
 }

--- a/src/DIPS.Xamarin.UI/Internal/Xaml/ToastContainer.xaml.cs
+++ b/src/DIPS.Xamarin.UI/Internal/Xaml/ToastContainer.xaml.cs
@@ -1,0 +1,26 @@
+﻿using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace DIPS.Xamarin.UI.Internal.Xaml
+{
+    [ContentProperty(nameof(MainContent))]
+    [XamlCompilation(XamlCompilationOptions.Compile)]
+    public partial class ToastContainer : ContentView
+    {
+        public static readonly BindableProperty MainContentProperty = BindableProperty.Create(
+            nameof(MainContent),
+            typeof(View),
+            typeof(ToastContainer));
+
+        public ToastContainer()
+        {
+            InitializeComponent();
+        }
+
+        public View MainContent
+        {
+            get => (View)GetValue(MainContentProperty);
+            set => SetValue(MainContentProperty, value);
+        }
+    }
+}

--- a/src/DIPS.Xamarin.UI/Internal/Xaml/ToastContainer.xaml.cs
+++ b/src/DIPS.Xamarin.UI/Internal/Xaml/ToastContainer.xaml.cs
@@ -9,6 +9,9 @@ namespace DIPS.Xamarin.UI.Internal.Xaml
     [XamlCompilation(XamlCompilationOptions.Compile)]
     public partial class ToastContainer : Grid
     {
+        /// <summary>
+        ///     Initialize Component
+        /// </summary>
         public ToastContainer()
         {
             InitializeComponent();

--- a/src/Samples/DIPS.Xamarin.UI.Samples/Controls/Toast/ToastPage.xaml
+++ b/src/Samples/DIPS.Xamarin.UI.Samples/Controls/Toast/ToastPage.xaml
@@ -4,36 +4,37 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="DIPS.Xamarin.UI.Samples.Controls.Toast.ToastPage"
              x:Name="toastPage"
-             xmlns:ViewModel="clr-namespace:DIPS.Xamarin.UI.Samples.Controls.Toast;assembly=DIPS.Xamarin.UI.Samples">
-        
+             xmlns:ViewModel="clr-namespace:DIPS.Xamarin.UI.Samples.Controls.Toast;assembly=DIPS.Xamarin.UI.Samples"
+             xmlns:xaml="clr-namespace:DIPS.Xamarin.UI.Internal.Xaml;assembly=DIPS.Xamarin.UI">
+ 
         <ContentPage.BindingContext>
                 <ViewModel:ToastPageViewModel />
         </ContentPage.BindingContext>
 
         <ContentPage.Content>
-
-        <StackLayout>
-            <Label Text="{Binding PageTitle}"
+        <xaml:ToastContainer>
+            <StackLayout>
+                <Label Text="{Binding PageTitle}"
                    VerticalOptions="CenterAndExpand"
                    HorizontalOptions="CenterAndExpand" />
-            <Button Text="Show Toast Moon"
+                <Button Text="Show Toast Moon"
                     Margin="15,0,15,40"
                     Command="{Binding MoonCommand}"
                     CommandParameter="Hello, Moon!" />
-            <Button Text="Show Toast Venus"
+                <Button Text="Show Toast Venus"
                     Margin="15,0,15,40"
                     Command="{Binding VenusCommand}"
                     CommandParameter="Hello, Venus! Second planet from the Sun! Named after the Roman goddess of love and beauty!" />
-            <Button Text="Show Toast Mars"
+                <Button Text="Show Toast Mars"
                     Margin="15,0,15,40"
                     Command="{Binding MarsCommand}"
                     CommandParameter="Hello, Mars! The fourth planet of the Milky Way! The Red planet! The planet for War!" />
-            <Button Text="Show Toast Pluto"
+                <Button Text="Show Toast Pluto"
                     Margin="15,0,15,40"
                     Command="{Binding PlutoCommand}"
                     CommandParameter="Hello, Pluto!" />
-        </StackLayout>
-
+            </StackLayout>
+        </xaml:ToastContainer>
     </ContentPage.Content>
 
 </ContentPage>


### PR DESCRIPTION
## Fixed

- Fixed a bug

## Todo List
- [X] I have tested on an Android device.
- [X] I have tested on an iOS device.
- [ ] I have added unit tests

When using ToastContainer wrapper, the toast is added and removed to the wrapper which itself is a grid. 
The existing implementation is valid when there is no wrapper used.

This fix following issues
- Reset scroll position of the page when toast appears
- Disable buttons on the view when a toast is being displayed
