### PR TITLE
Invoke CancelCommand for SheetView when tapping on the overlay

### DIFF
--- a/src/DIPS.Xamarin.UI/Controls/Sheet/SheetBehavior.cs
+++ b/src/DIPS.Xamarin.UI/Controls/Sheet/SheetBehavior.cs
@@ -871,7 +871,7 @@ namespace DIPS.Xamarin.UI.Controls.Sheet
         /// <inheritdoc />
         public void Hide()
         {
-            IsOpen = false;
+            CancelClickedInternal();
         }
 
         /// <inheritdoc />

--- a/src/DIPS.Xamarin.UI/Controls/Sheet/SheetBehavior.cs
+++ b/src/DIPS.Xamarin.UI/Controls/Sheet/SheetBehavior.cs
@@ -871,6 +871,7 @@ namespace DIPS.Xamarin.UI.Controls.Sheet
         /// <inheritdoc />
         public void Hide()
         {
+            CancelCommand?.Execute(CancelCommandParameter);
             CancelClickedInternal();
         }
 

--- a/src/Samples/DIPS.Xamarin.UI.Samples/Controls/Sheet/SheetPage.xaml
+++ b/src/Samples/DIPS.Xamarin.UI.Samples/Controls/Sheet/SheetPage.xaml
@@ -16,6 +16,7 @@
     <dxui:ModalityLayout>
         <dxui:ModalityLayout.Behaviors>
             <dxui:SheetBehavior Title="{Binding Title}"
+                                CancelCommand="{Binding CancelCommand}"
                                 VerticalContentAlignment="{Binding VerticalContentAlignment}"
                                 ActionCommand="{Binding ActionCommand}"
                                 ActionTitle="{Binding HasActionButton, Converter={dxui:BoolToObjectConverter FalseObject='', TrueObject=CanExecute}}"

--- a/src/Samples/DIPS.Xamarin.UI.Samples/Controls/Sheet/SheetPage.xaml.cs
+++ b/src/Samples/DIPS.Xamarin.UI.Samples/Controls/Sheet/SheetPage.xaml.cs
@@ -47,10 +47,10 @@ namespace DIPS.Xamarin.UI.Samples.Controls.Sheet
             OpenSheetCommand = new Command(() => IsSheetOpen = true);
             OnOpenCommand = new Command<string>(SheetOpened);
             OnCloseCommand = new Command<string>(SheetClosed);
-            CancelCommand = new CancelSheetCommand(
-                () =>
+            CancelCommand = new CancelSheetCommand(async () =>
                 {
-
+                    await Application.Current.MainPage.DisplayAlert("An Asynchronous action", "Async action", "Ok");
+                    IsSheetOpen = false;
                 },
                 () =>
                 {
@@ -59,7 +59,7 @@ namespace DIPS.Xamarin.UI.Samples.Controls.Sheet
                 }, async () =>
                {
                    //Do logic to determine if the sheet should close
-                  return await App.Current.MainPage.DisplayAlert("Confirmation", "Do you really want to close this?", "Yes", "No");
+                   return false;
                });
 
             ActionCommand = new Command(

--- a/src/Samples/DIPS.Xamarin.UI.Samples/Controls/Sheet/SheetPage.xaml.cs
+++ b/src/Samples/DIPS.Xamarin.UI.Samples/Controls/Sheet/SheetPage.xaml.cs
@@ -47,10 +47,9 @@ namespace DIPS.Xamarin.UI.Samples.Controls.Sheet
             OpenSheetCommand = new Command(() => IsSheetOpen = true);
             OnOpenCommand = new Command<string>(SheetOpened);
             OnCloseCommand = new Command<string>(SheetClosed);
-            CancelCommand = new CancelSheetCommand(async () =>
+            CancelCommand = new CancelSheetCommand(() =>
                 {
-                    await Application.Current.MainPage.DisplayAlert("An Asynchronous action", "Async action", "Ok");
-                    IsSheetOpen = false;
+                    //Do any logic that should get executed regardless of the canCloseSheet logic.
                 },
                 () =>
                 {
@@ -59,7 +58,7 @@ namespace DIPS.Xamarin.UI.Samples.Controls.Sheet
                 }, async () =>
                {
                    //Do logic to determine if the sheet should close
-                   return false;
+                   return await Application.Current.MainPage.DisplayAlert("Are you sure?", "Do you want to close the sheet view?", "Yes", "No");
                });
 
             ActionCommand = new Command(

--- a/src/Samples/DIPS.Xamarin.UI.Samples/Controls/Sheet/SheetPage.xaml.cs
+++ b/src/Samples/DIPS.Xamarin.UI.Samples/Controls/Sheet/SheetPage.xaml.cs
@@ -56,10 +56,10 @@ namespace DIPS.Xamarin.UI.Samples.Controls.Sheet
                 {
                     return true;
 
-                }, () =>
+                }, async () =>
                {
                    //Do logic to determine if the sheet should close
-                   return true;
+                  return await App.Current.MainPage.DisplayAlert("Confirmation", "Do you really want to close this?", "Yes", "No");
                });
 
             ActionCommand = new Command(


### PR DESCRIPTION
## Added
- Ensure that the CanCloseSheet value is respected when the overlay is tapped while the SheetView  is open
- Invoke the CancelCommand when the overlay is tapped while the SheetView is open

## Todo List

- [x] I have tested on an Android device.
- [x] I have tested on an iOS device.
- [ ] I have added unit tests

>*Please add pictures / Gifs if possible*
>*Todo List can be checked by putting a `X` inside the brackets*
>*Remember to update our `wiki` after this PR is merged*
