### PR TITLE
Convert date time to local time zone before to formatting

### DIFF
--- a/src/DIPS.Xamarin.UI/Converters/ValueConverters/DateAndTimeConverter.cs
+++ b/src/DIPS.Xamarin.UI/Converters/ValueConverters/DateAndTimeConverter.cs
@@ -9,7 +9,7 @@ using Xamarin.Forms.Xaml;
 namespace DIPS.Xamarin.UI.Converters.ValueConverters
 {
     /// <summary>
-    ///     Converters a DateTime object with an format and convert it to a readable string
+    ///     Converters a DateTime object with a format and convert it to a readable string in local time zone
     /// </summary>
     public class DateAndTimeConverter : IMarkupExtension, IValueConverter
     {
@@ -36,6 +36,11 @@ namespace DIPS.Xamarin.UI.Converters.ValueConverters
             Text,
         }
 
+        /// <summary>
+        ///     Ignores the conversion to local timezone
+        /// </summary>
+        public bool IgnoreLocalTime { get; set; } = false;
+
         private const string Space = " ";
         private IServiceProvider m_serviceProvider;
 
@@ -60,9 +65,9 @@ namespace DIPS.Xamarin.UI.Converters.ValueConverters
                 throw new XamlParseException("The input has to be of type DateTime").WithXmlLineInfo(m_serviceProvider);
             return Format switch
             {
-                DateAndTimeConverterFormat.Short => ConvertToShortFormat(dateTimeInput, culture),
+                DateAndTimeConverterFormat.Short => ConvertToShortFormat(dateTimeInput, culture, IgnoreLocalTime),
                 DateAndTimeConverterFormat.Text
-                    => ConvertToTextFormat(dateTimeInput, culture),
+                    => ConvertToTextFormat(dateTimeInput, culture, IgnoreLocalTime),
                 _ => string.Empty
             };
         }
@@ -74,11 +79,11 @@ namespace DIPS.Xamarin.UI.Converters.ValueConverters
             throw new NotImplementedException();
         }
 
-        private static string ConvertToTextFormat(DateTime dateTimeInput, CultureInfo culture)
+        private static string ConvertToTextFormat(DateTime dateTimeInput, CultureInfo culture, bool ignoreLocalTime)
         {
-            var date = new DateConverter {Format = DateConverter.DateConverterFormat.Text}.Convert(dateTimeInput, null,
+            var date = new DateConverter {Format = DateConverter.DateConverterFormat.Text, IgnoreLocalTime = ignoreLocalTime}.Convert(dateTimeInput, null,
                 null, culture);
-            var time = new TimeConverter {Format = TimeConverter.TimeConverterFormat.Default}.Convert(dateTimeInput,
+            var time = new TimeConverter {Format = TimeConverter.TimeConverterFormat.Default, IgnoreLocalTime = ignoreLocalTime}.Convert(dateTimeInput,
                 null, null, culture);
 
             if (culture.IsNorwegian())
@@ -94,11 +99,11 @@ namespace DIPS.Xamarin.UI.Converters.ValueConverters
             return $"{date}{Space}{time}";
         }
 
-        private static string ConvertToShortFormat(DateTime dateTimeInput, CultureInfo culture)
+        private static string ConvertToShortFormat(DateTime dateTimeInput, CultureInfo culture, bool ignoreLocalTime)
         {
-            var date = new DateConverter {Format = DateConverter.DateConverterFormat.Short}.Convert(dateTimeInput, null,
+            var date = new DateConverter {Format = DateConverter.DateConverterFormat.Short, IgnoreLocalTime = ignoreLocalTime}.Convert(dateTimeInput, null,
                 null, culture);
-            var time = new TimeConverter {Format = TimeConverter.TimeConverterFormat.Default}.Convert(dateTimeInput,
+            var time = new TimeConverter {Format = TimeConverter.TimeConverterFormat.Default, IgnoreLocalTime = ignoreLocalTime}.Convert(dateTimeInput,
                 null, null, culture);
 
             return culture.IsNorwegian() ? $"{date}{Space}kl{Space}{time}" : $"{date}{Space}{time}";

--- a/src/DIPS.Xamarin.UI/Converters/ValueConverters/DateConverter.cs
+++ b/src/DIPS.Xamarin.UI/Converters/ValueConverters/DateConverter.cs
@@ -10,7 +10,7 @@ using Xamarin.Forms.Xaml;
 namespace DIPS.Xamarin.UI.Converters.ValueConverters
 {
     /// <summary>
-    ///     Converts an DateTime object to an format and convert it to a readable string
+    ///     Converts an DateTime object to a format and convert it to a readable string in local timezone
     /// </summary>
     public class DateConverter : IValueConverter, IMarkupExtension
     {
@@ -48,6 +48,11 @@ namespace DIPS.Xamarin.UI.Converters.ValueConverters
         /// </summary>
         public DateConverterFormat Format { get; set; }
 
+        /// <summary>
+        ///     Ignores the conversion to the local timezone
+        /// </summary>
+        public bool IgnoreLocalTime { get; set; }
+
         /// <inheritdoc />
         [ExcludeFromCodeCoverage]
         public object ProvideValue(IServiceProvider serviceProvider)
@@ -64,9 +69,9 @@ namespace DIPS.Xamarin.UI.Converters.ValueConverters
                 throw new XamlParseException("The input has to be of type DateTime").WithXmlLineInfo(m_serviceProvider);
             return Format switch
             {
-                DateConverterFormat.Short => ConvertToDefaultDateTime(dateTimeInput, culture),
+                DateConverterFormat.Short => ConvertToDefaultDateTime(dateTimeInput, culture, IgnoreLocalTime),
                 DateConverterFormat.Text =>
-                    ConvertDateTimeAsText(dateTimeInput, culture),
+                    ConvertDateTimeAsText(dateTimeInput, culture, IgnoreLocalTime),
                 _ => string.Empty
             };
         }
@@ -78,8 +83,13 @@ namespace DIPS.Xamarin.UI.Converters.ValueConverters
             throw new NotImplementedException();
         }
 
-        private static string ConvertToDefaultDateTime(DateTime dateTime, CultureInfo culture)
+        private static string ConvertToDefaultDateTime(DateTime dateTime, CultureInfo culture, bool ignoreLocalTime)
         {
+            if (!ignoreLocalTime)
+            {
+                dateTime = dateTime.ToLocalTime();
+            }
+
             var day = GetDayBasedOnCulture(dateTime, culture);
 
             var month = GetMonthBasedOnCulture(dateTime, culture);
@@ -114,8 +124,13 @@ namespace DIPS.Xamarin.UI.Converters.ValueConverters
             return day;
         }
 
-        private static string ConvertDateTimeAsText(DateTime dateTime, CultureInfo culture)
+        private static string ConvertDateTimeAsText(DateTime dateTime, CultureInfo culture, bool ignoreLocalTime)
         {
+            if (!ignoreLocalTime)
+            {
+                dateTime = dateTime.ToLocalTime();
+            }
+            
             if (dateTime.IsToday())
             {
                 return InternalLocalizedStrings.Today;

--- a/src/DIPS.Xamarin.UI/Converters/ValueConverters/TimeConverter.cs
+++ b/src/DIPS.Xamarin.UI/Converters/ValueConverters/TimeConverter.cs
@@ -9,7 +9,8 @@ using Xamarin.Forms.Xaml;
 namespace DIPS.Xamarin.UI.Converters.ValueConverters
 {
     /// <summary>
-    ///     Converts an DateTime or TimeSpan object with a format and convert it to a readable time string
+    ///     Converts an DateTime or TimeSpan object with a format and convert it to a readable time string in local
+    ///     timezone
     /// </summary>
     public class TimeConverter : IMarkupExtension, IValueConverter
     {
@@ -31,6 +32,11 @@ namespace DIPS.Xamarin.UI.Converters.ValueConverters
         ///     The format to use during conversion
         /// </summary>
         public TimeConverterFormat Format { get; set; }
+
+        /// <summary>
+        ///     Ignores the conversion to the local timezone
+        /// </summary>
+        public bool IgnoreLocalTime { get; set; }
 
         /// <inheritdoc />
         [ExcludeFromCodeCoverage]
@@ -55,7 +61,7 @@ namespace DIPS.Xamarin.UI.Converters.ValueConverters
                     dateTimeInput += timeSpanInput;
                     break;
                 case DateTime dateTimeValue:
-                    dateTimeInput = dateTimeValue;
+                    dateTimeInput = IgnoreLocalTime ? dateTimeValue : dateTimeValue.ToLocalTime();
                     break;
             }
 


### PR DESCRIPTION
## Convert date times to local time zone before formatting them

- Allow skipping conversion to local time zone with IgnoreLocalTime flag in converter

## Todo List

- [x] I have tested on an Android device.
- [x] I have tested on an iOS device.
- [ ] I have added unit tests

>*Please add pictures / Gifs if possible*
>*Todo List can be checked by putting a `X` inside the brackets*
>*Remember to update our `wiki` after this PR is merged*
