### PR TITLE
Removed unnecessary null check

### DIFF
--- a/src/DIPS.Xamarin.UI/Controls/Slidable/SlidableLayout.cs
+++ b/src/DIPS.Xamarin.UI/Controls/Slidable/SlidableLayout.cs
@@ -225,7 +225,7 @@ namespace DIPS.Xamarin.UI.Controls.Slidable
         private void OnScrolledInternal(bool initial = false)
         {
             var index = (int)Math.Round(SlideProperties.Position);
-            if (index != m_lastIndex && SelectedItemChangedCommand != null)
+            if (index != m_lastIndex)
             {
                 if (!initial)
                 {


### PR DESCRIPTION
## Added / Fixed

- Unnecessary null check caused vibration not to work if `SelectedItemChangedCommand` was not set

## Todo List

- [ ] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have added unit tests

>*Please add pictures / Gifs if possible*
>*Todo List can be checked by putting a `X` inside the brackets*
>*Remember to update our `wiki` after this PR is merged*
