### PR TITLE
Added public Redraw() method for redrawing slidable content layout

### DIFF
--- a/src/DIPS.Xamarin.UI/Controls/Slidable/SlidableContentLayout.cs
+++ b/src/DIPS.Xamarin.UI/Controls/Slidable/SlidableContentLayout.cs
@@ -29,6 +29,15 @@ namespace DIPS.Xamarin.UI.Controls.Slidable
             Content = m_container;
             m_container.IsClippedToBounds = true;
         }
+
+        /// <summary>
+        ///     Signals to the control that its content should be redrawn.
+        /// </summary>
+        public void Redraw()
+        {
+            ResetAll();
+        }
+        
         /// <summary>
         /// <inheritdoc/>
         /// </summary>


### PR DESCRIPTION
## Added / Fixed

- Added public Redraw() method for allowing a manual redraw of the content of the `SlidableContentLayout`.

## Todo List

- [x] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have added unit tests
