### PR TITLE
Added InvertedBool markup extension

### DIFF
--- a/src/DIPS.Xamarin.UI/Extensions/Markup/InvertedBoolExtension.cs
+++ b/src/DIPS.Xamarin.UI/Extensions/Markup/InvertedBoolExtension.cs
@@ -1,0 +1,25 @@
+using System;
+using DIPS.Xamarin.UI.Converters.ValueConverters;
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace DIPS.Xamarin.UI.Extensions.Markup
+{
+    /// <summary>
+    /// This markup extension lets you use <see cref="InvertedBoolConverter"/> when you are referring a static property from some class.
+    /// </summary>
+    [ContentProperty(nameof(Input))]
+    public class InvertedBoolExtension : IMarkupExtension
+    {
+        /// <summary>
+        /// The boolean input to invert
+        /// </summary>
+        public bool Input { get; set; }
+
+        /// <inheritdoc cref="IMarkupExtension"/>
+        public object ProvideValue(IServiceProvider serviceProvider)
+        {
+            return new InvertedBoolConverter().Convert(Input, null, null, null);
+        }
+    }
+}


### PR DESCRIPTION
## Added / Fixed

- Added a InvertedBool markup extension, this can be used like so:
```xml
<Label IsVisible="{markup:BoolInverter Value={x:Static MyClass.MyStaticBoolProperty}}" />
```

## Todo List

- [ ] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have added unit tests
