### PR TITLE
Fixed SlidableContentLayout not scrolling on some Samsung devices

### DIFF
--- a/src/DIPS.Xamarin.UI.Android/Util/SlidableLayoutContentView.cs
+++ b/src/DIPS.Xamarin.UI.Android/Util/SlidableLayoutContentView.cs
@@ -72,22 +72,15 @@ namespace DIPS.Xamarin.UI.Android.Util
 
         private bool StartScroll(MotionEvent ev)
         {
-            try
+            var x = ev.GetX();
+            var delta = m_lastXPosition - x ?? 0.0f;
+            m_lastXPosition = x;
+            
+            if (Math.Abs(delta) > m_scaledTouchSlop) // Increase value if we require a longer drag before scrolling starts.
             {
-                var x = ev.GetX();
-                var delta = m_lastXPosition - x ?? 0.0f;
-                m_lastXPosition = x;
-                
-                if (Math.Abs(delta) > m_scaledTouchSlop) // Increase value if we require a longer drag before scrolling starts.
-                {
-                    m_isScrolling = true;
-                    m_elem?.SendPan(0, 0, GestureStatus.Started, m_pointerId);
-                    return true;
-                }
-            }
-            catch (Exception e)
-            {
-                Console.WriteLine(e);
+                m_isScrolling = true;
+                m_elem?.SendPan(0, 0, GestureStatus.Started, m_pointerId);
+                return true;
             }
 
             return false;


### PR DESCRIPTION
## Added / Fixed

- Fixed SlidableContentLayout not scrolling on some Samsung devices
- The issue comes from `HistorySize` not always being greater than 0 although there actually are historical points. Therefore, it's better to just manually cache the previous position and scroll based on that

## Todo List

- [x] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have added unit tests
