### PR TITLE
[ContextMenu] Improvements to Android icon and auto-close when app goes to background

### DIFF
--- a/src/DIPS.Xamarin.UI.Android/ContextMenu/ContextMenuHelper.cs
+++ b/src/DIPS.Xamarin.UI.Android/ContextMenu/ContextMenuHelper.cs
@@ -92,8 +92,14 @@ namespace DIPS.Xamarin.UI.Android.ContextMenu
             if (!string.IsNullOrEmpty(contextMenuItem.Icon))
             {
                 var id = context.Resources?.GetIdentifier(contextMenuItem.Icon, "drawable", context.PackageName);
-                var androidResourceId = context.Resources?.GetIdentifier(contextMenuItem.AndroidOptions.IconResourceName, "drawable",context.PackageName);
-                id = androidResourceId ?? id;
+                if (!string.IsNullOrEmpty(contextMenuItem.AndroidOptions.IconResourceName))
+                {
+                    var androidResourceId= context.Resources?.GetIdentifier(contextMenuItem.AndroidOptions.IconResourceName, "drawable",context.PackageName);
+                    if (androidResourceId != null)
+                    {
+                        id = androidResourceId;
+                    }
+                }
                 if (id != null)
                 {
                     menuItem.SetIcon((int)id);   

--- a/src/DIPS.Xamarin.UI.iOS/ContextMenu/ContextMenuButtonRenderer.cs
+++ b/src/DIPS.Xamarin.UI.iOS/ContextMenu/ContextMenuButtonRenderer.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using CoreGraphics;
 using DIPS.Xamarin.UI.Controls.ContextMenu;
 using DIPS.Xamarin.UI.iOS.ContextMenu;
+using Foundation;
 using ObjCRuntime;
 using UIKit;
 using Xamarin.Forms;
@@ -35,6 +36,11 @@ namespace DIPS.Xamarin.UI.iOS.ContextMenu
                             CreateMenu(); //Create the menu the first time so it shows up the first time the user taps the button
                         Control.TouchDown += OnTouchDown;
                         Control.ShowsMenuAsPrimaryAction = true;
+                        NSNotificationCenter.DefaultCenter.AddObserver(UIApplication.DidEnterBackgroundNotification, notification =>
+                        {
+                            Control.Menu = null;
+                            Control.Menu = CreateMenu(); //Recreate the menu to close it, and to make it possible to re-open it in one tap after it went to the background
+                        });
                     }
                 }
             }
@@ -43,6 +49,7 @@ namespace DIPS.Xamarin.UI.iOS.ContextMenu
                 if (Control != null)
                 {
                     Control.TouchDown -= OnTouchDown;
+                    NSNotificationCenter.DefaultCenter.RemoveObserver(UIApplication.DidEnterBackgroundNotification);
                 }
             }
         }


### PR DESCRIPTION
## Added / Fixed

- Made sure Android does not crash when a icon is added to the context menu item
- Made sure context menu is closed when app goes to background on both android and iOS

## Todo List

- [X] I have tested on an Android device.
- [ ] I have tested on an iOS device.
- [ ] I have added unit tests
