### PR TITLE
Made sure to dispose context menu buttons in the platforms correctly

### DIFF
--- a/src/DIPS.Xamarin.UI.Android/ContextMenu/ContextMenuButtonRenderer.cs
+++ b/src/DIPS.Xamarin.UI.Android/ContextMenu/ContextMenuButtonRenderer.cs
@@ -37,22 +37,24 @@ namespace DIPS.Xamarin.UI.Android.ContextMenu
         {
             base.OnElementChanged(e);
 
-            if (e.NewElement is ContextMenuButton contextMenuButton)
+            if (e.NewElement is ContextMenuButton m_contextMenuButton)
             {
-                m_contextMenuButton = contextMenuButton;
+                m_contextMenuButton = m_contextMenuButton;
                 if (Control != null)
                 {
                     {
-                        contextMenuButton.Clicked += OpenContextMenu;
+                        m_contextMenuButton.Clicked += OpenContextMenu;
                         (((Activity)Context!)).RegisterActivityLifecycleCallbacks(this);
                     }
                 }
-                else
-                {
-                    contextMenuButton.Clicked -= OpenContextMenu;
-                    (((Activity)Context!)).UnregisterActivityLifecycleCallbacks(this);
-                }
             }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            m_contextMenuButton.Clicked -= OpenContextMenu;
+            (((Activity)Context!)).UnregisterActivityLifecycleCallbacks(this);
+            base.Dispose(disposing);
         }
 
         private void OpenContextMenu(object sender, EventArgs e)

--- a/src/DIPS.Xamarin.UI.iOS/ContextMenu/ContextMenuButtonRenderer.cs
+++ b/src/DIPS.Xamarin.UI.iOS/ContextMenu/ContextMenuButtonRenderer.cs
@@ -19,6 +19,7 @@ namespace DIPS.Xamarin.UI.iOS.ContextMenu
     internal class ContextMenuButtonRenderer : ButtonRenderer
     {
         private ContextMenuButton m_contextMenuButton;
+        private NSObject m_didEnterBackgroundNotificationObserver;
         internal static void Initialize() { }
 
         protected override void OnElementChanged(ElementChangedEventArgs<Button> e)
@@ -36,7 +37,7 @@ namespace DIPS.Xamarin.UI.iOS.ContextMenu
                             CreateMenu(); //Create the menu the first time so it shows up the first time the user taps the button
                         Control.TouchDown += OnTouchDown;
                         Control.ShowsMenuAsPrimaryAction = true;
-                        NSNotificationCenter.DefaultCenter.AddObserver(UIApplication.DidEnterBackgroundNotification, notification =>
+                        m_didEnterBackgroundNotificationObserver = NSNotificationCenter.DefaultCenter.AddObserver(UIApplication.DidEnterBackgroundNotification, notification =>
                         {
                             Control.Menu = null;
                             Control.Menu = CreateMenu(); //Recreate the menu to close it, and to make it possible to re-open it in one tap after it went to the background
@@ -44,14 +45,13 @@ namespace DIPS.Xamarin.UI.iOS.ContextMenu
                     }
                 }
             }
-            else
-            {
-                if (Control != null)
-                {
-                    Control.TouchDown -= OnTouchDown;
-                    NSNotificationCenter.DefaultCenter.RemoveObserver(UIApplication.DidEnterBackgroundNotification);
-                }
-            }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            Control.TouchDown -= OnTouchDown;
+            NSNotificationCenter.DefaultCenter.RemoveObserver(m_didEnterBackgroundNotificationObserver);
+            base.Dispose(disposing);
         }
 
         private void OnTouchDown(object sender, EventArgs e)


### PR DESCRIPTION
## Added / Fixed

Made sure to dispose context menu buttons in the platforms correctly to provent crashes if people navigate out of the page that the context menu was added and then send the app to background.